### PR TITLE
fix(morpho): pass vaultAddress through withdrawal flow to enable vault exits

### DIFF
--- a/components/earn-yield/PositionsList.tsx
+++ b/components/earn-yield/PositionsList.tsx
@@ -91,6 +91,7 @@ export function PositionsList({ positions, yields, isLoading, onExitSuccess }: P
         body: JSON.stringify({
           protocol: position.protocol || "morpho",
           userAddress: wallet.address,
+          vaultAddress: position.vaultAddress,
           // For Morpho, we withdraw all shares
           // The position.amount is in USDC units, convert to smallest unit (6 decimals)
           shares: position.shares || (BigInt(Math.floor(parseFloat(position.amount) * 1e6))).toString(),

--- a/lib/yield-optimizer/executor.ts
+++ b/lib/yield-optimizer/executor.ts
@@ -198,7 +198,8 @@ export async function buildWithdrawTransaction(
   protocol: string,
   userAddress: `0x${string}`,
   shares?: bigint,
-  assets?: bigint
+  assets?: bigint,
+  vaultAddress?: `0x${string}`
 ): Promise<DepositTransactionResult> {
   const transactions: DepositTransactionResult["transactions"] = [];
 
@@ -211,7 +212,7 @@ export async function buildWithdrawTransaction(
     }
 
     // Build withdrawal transaction
-    const withdrawTx = buildMorphoWithdrawTx(userAddress, shares, assets);
+    const withdrawTx = buildMorphoWithdrawTx(userAddress, shares, assets, vaultAddress);
     
     transactions.push({
       id: `withdraw-${Date.now()}`,


### PR DESCRIPTION
## Summary
Fixed withdrawal failures from Morpho Vaults by passing the vault address through the entire withdrawal flow, ensuring ERC4626 vault methods are called instead of Morpho Blue directly.

## Changes
- Pass `vaultAddress` from frontend through API to executor
- Add validation for vault address format
- Update `buildWithdrawTransaction()` to forward vault address to Morpho builder

## Problem Solved
Vault exits were failing with "market not created" error because the system incorrectly called Morpho Blue's direct market `withdraw()` function instead of the vault's ERC4626 `redeem()` function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)