### PR TITLE
fix: Update cron schedule for Vercel Hobby tier

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/agent/cron",
-      "schedule": "*/5 * * * *"
+      "schedule": "0 12 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Changed cron schedule from `*/5 * * * *` (every 5 min) to `0 12 * * *` (daily at noon UTC)
- Vercel Hobby tier only supports daily cron jobs; the previous schedule caused deployment failures

## Test plan
- [ ] Verify `vercel deploy` succeeds without cron frequency error
- [ ] Confirm cron job triggers daily at noon UTC
