### PR TITLE
fix: upgrade ZeroDev RPC URLs from v2 to v3 with chain ID

### DIFF
--- a/app/api/agent/health/route.ts
+++ b/app/api/agent/health/route.ts
@@ -42,7 +42,7 @@ export async function GET(request: NextRequest) {
       if (projectId) {
         // Simple bundler availability check
         const bundlerUrl = process.env.ZERODEV_BUNDLER_URL ||
-          `https://rpc.zerodev.app/api/v2/bundler/${projectId}`;
+          `https://rpc.zerodev.app/api/v3/${projectId}/chain/8453`;
         const response = await fetch(bundlerUrl, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/lib/zerodev/kernel-client.ts
+++ b/lib/zerodev/kernel-client.ts
@@ -74,9 +74,19 @@ export async function createSessionKernelClient(params: CreateSessionKernelClien
     kernelVersion: KERNEL_V3_1,
   });
 
+  // Verify the kernel account address matches what was stored
+  if (kernelAccount.address.toLowerCase() !== params.smartAccountAddress.toLowerCase()) {
+    console.error('[KernelClient] ⚠️ Address mismatch!', {
+      computed: kernelAccount.address,
+      stored: params.smartAccountAddress,
+    });
+  } else {
+    console.log('[KernelClient] ✓ Address verified:', kernelAccount.address);
+  }
+
   // 8. Create Kernel account client with bundler
   const bundlerUrl = process.env.ZERODEV_BUNDLER_URL ||
-    `https://rpc.zerodev.app/api/v2/bundler/${process.env.ZERODEV_PROJECT_ID}`;
+    `https://rpc.zerodev.app/api/v3/${process.env.ZERODEV_PROJECT_ID}/chain/8453`;
 
   const kernelClient = await createKernelAccountClient({
     account: kernelAccount,


### PR DESCRIPTION
Shipped via `/ship`