### PR TITLE
chore: enable HTTPS for local development

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Tapioca Finance — smart yield optimization on Base with autonomous DeFi agent",
   "license": "proprietary",
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev --turbopack --experimental-https",
     "build": "next build",
     "start": "next start",
     "format": "prettier --write .",


### PR DESCRIPTION
Add --experimental-https flag to Next.js dev server to enable secure context features during development. Useful for testing features that require HTTPS like certain Privy wallet configurations.