### PR TITLE
chore: add certificates directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ next-env.d.ts
 
 .claude
 .mux
+certificates


### PR DESCRIPTION
Exclude local certificates/ directory from version control. Contains self-signed HTTPS certificates for local development.