### PR TITLE
refact: ZeroDev corrections

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,7 +2,7 @@
 NEXT_PUBLIC_PRIVY_APP_ID=                        # Get from https://dashboard.privy.io
 PRIVY_APP_SECRET=                                 # Secret key from Privy dashboard
 
-# ZeroDev Smart Accounts (Kernel V3)
+# ZeroDev Smart Accounts (Kernel V3) — server-side only
 ZERODEV_PROJECT_ID=                              # Get from https://dashboard.zerodev.app
 ZERODEV_BUNDLER_URL=                             # Optional: Custom bundler URL (defaults to ZeroDev's)
 

--- a/app/api/agent/cron/route.ts
+++ b/app/api/agent/cron/route.ts
@@ -333,11 +333,13 @@ async function executeRebalanceTransaction(
 
     // 3. Execute via ZeroDev using session key with scoped permissions
     const approvedVaults = authorization.approvedVaults as `0x${string}`[] | undefined;
+    const eip7702SignedAuth = authorization.eip7702SignedAuth;
     const executionResult = await executeRebalance(
       smartAccountAddress,
       rebalanceParams,
       sessionPrivateKey as `0x${string}`,
-      approvedVaults
+      approvedVaults,
+      eip7702SignedAuth,
     );
 
     const taskId = executionResult.taskId || `zerodev_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;

--- a/app/api/agent/generate-session-key/route.ts
+++ b/app/api/agent/generate-session-key/route.ts
@@ -34,6 +34,7 @@ interface GenerateSessionKeyRequest {
   address: string;
   smartAccountAddress: string;
   approvedVaults: string[];
+  eip7702SignedAuth?: any; // Signed EIP-7702 authorization from Privy
 }
 
 /**
@@ -43,7 +44,7 @@ interface GenerateSessionKeyRequest {
 export async function POST(request: NextRequest) {
   try {
     const body: GenerateSessionKeyRequest = await request.json();
-    const { address, smartAccountAddress, approvedVaults } = body;
+    const { address, smartAccountAddress, approvedVaults, eip7702SignedAuth } = body;
 
     // Validate required fields
     if (!address) {
@@ -98,6 +99,7 @@ export async function POST(request: NextRequest) {
       approvedVaults: approvedVaults as `0x${string}`[],
       expiry,
       timestamp: Date.now(),
+      ...(eip7702SignedAuth ? { eip7702SignedAuth } : {}),
     };
 
     const encryptedAuth = encryptAuthorization(authorization);

--- a/lib/agent/rebalance-executor.ts
+++ b/lib/agent/rebalance-executor.ts
@@ -115,7 +115,8 @@ export async function executeRebalance(
   smartAccountAddress: `0x${string}`,
   params: RebalanceParams,
   sessionPrivateKey: `0x${string}`,
-  approvedVaults?: `0x${string}`[]
+  approvedVaults?: `0x${string}`[],
+  eip7702SignedAuth?: any,
 ): Promise<RebalanceResult> {
   try {
     console.log('[Rebalance] Starting ZeroDev execution with scoped permissions...');
@@ -139,6 +140,7 @@ export async function executeRebalance(
       smartAccountAddress,
       sessionPrivateKey,
       permissions,
+      eip7702SignedAuth,
     });
 
     // Build rebalance calls

--- a/lib/security/session-encryption.ts
+++ b/lib/security/session-encryption.ts
@@ -12,6 +12,15 @@ export interface SessionKey7702Authorization {
   approvedVaults: string[];
   expiry: number;
   timestamp: number;
+  eip7702SignedAuth?: {              // Signed EIP-7702 authorization from client
+    r: string;
+    s: string;
+    yParity: number;
+    v?: string;                      // bigint serialized as string
+    address: string;                 // Implementation contract address
+    chainId: number;
+    nonce: number;
+  };
 }
 
 export interface TransferSessionAuthorization {

--- a/lib/zerodev/deposit-executor.ts
+++ b/lib/zerodev/deposit-executor.ts
@@ -26,6 +26,7 @@ export interface VaultDepositParams {
   amount: string; // Amount in USDC (e.g., "10.50")
   sessionPrivateKey: `0x${string}`;
   approvedVaults?: `0x${string}`[];
+  eip7702SignedAuth?: any; // Stored signed EIP-7702 authorization
 }
 
 export interface VaultDepositResult {
@@ -77,6 +78,7 @@ export async function executeGaslessDeposit(
       smartAccountAddress: params.smartAccountAddress,
       sessionPrivateKey: params.sessionPrivateKey,
       permissions,
+      eip7702SignedAuth: params.eip7702SignedAuth,
     });
 
     // Build approve + deposit calls (batched atomically)


### PR DESCRIPTION
## Summary
- **Fixed AA14 error**: Move EIP-7702 delegation deployment to server-side (first UserOp). Client now only signs the authorization via Privy.
- **Simplified client-secure.ts**: Removed all ZeroDev SDK usage (createKernelAccount, bundler calls, UserOp sending). Client just fetches vaults, signs auth, sends to server.
- **Pass signed auth through server execution**: Stored EIP-7702 signature persisted in DB, passed as `eip7702Auth` to ZeroDev SDK at execution time to set `isEip7702=true` (prevents factory initCode generation).

## Changes
- `client-secure.ts`: Stripped to sign + send flow, added `serializeSignedAuth` helper, removed client-side UserOp execution
- `useOptimizer.ts`: Added `useSign7702Authorization()` hook, sign auth before sending to server
- `session-encryption.ts`: Added `eip7702SignedAuth` field to authorization type
- `generate-session-key` route: Accept & store signed auth alongside session key
- `kernel-client.ts`: Accept `eip7702SignedAuth` param, deserialize `v` from string, pass as `eip7702Auth` to SDK
- `deposit-executor.ts`, `rebalance-executor.ts`, `cron/route.ts`: Thread signed auth through to kernel client creation
- `.env.template`: Removed `NEXT_PUBLIC_ZERODEV_PROJECT_ID` (client no longer talks to bundler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)