### PR TITLE
feat: Phase 2 — multi-protocol adapters, oracle, event monitor, audit fixes

### DIFF
--- a/lib/agent/event-monitor.ts
+++ b/lib/agent/event-monitor.ts
@@ -1,0 +1,127 @@
+import { MorphoClient, type MorphoVault } from '../morpho/api-client';
+import { getCacheInterface } from '../redis/client';
+
+const CHAIN_ID = 8453;
+const ASSET_SYMBOL = 'USDC';
+const APY_CHANGE_THRESHOLD = 0.01; // 1% absolute APY change triggers alert
+const CACHE_KEY_PREFIX = 'apy_baseline:';
+const BASELINE_TTL = 86400; // 24 hours - baseline refreshed daily
+
+export interface ApyChangeEvent {
+  vaultAddress: string;
+  vaultName: string;
+  previousApy: number;
+  currentApy: number;
+  changeAbsolute: number; // Absolute change (e.g., -0.02 = -2%)
+  changeRelative: number; // Relative change (e.g., -0.4 = -40%)
+  direction: 'up' | 'down';
+  timestamp: number;
+}
+
+export interface MonitorResult {
+  checked: number;
+  changes: ApyChangeEvent[];
+  affectedVaults: string[];
+}
+
+/**
+ * APY Change Detector
+ *
+ * Polls Morpho vaults and detects significant APY movements.
+ * Stores baseline APYs in Redis and compares on each poll.
+ */
+export class ApyEventMonitor {
+  private morphoClient: MorphoClient;
+  private threshold: number;
+
+  constructor(threshold: number = APY_CHANGE_THRESHOLD) {
+    this.morphoClient = new MorphoClient();
+    this.threshold = threshold;
+  }
+
+  /**
+   * Check all vaults for APY changes against stored baselines.
+   * Call this every 5 minutes via a fast-poll cron.
+   */
+  async detectChanges(): Promise<MonitorResult> {
+    const vaults = await this.morphoClient.fetchVaults(CHAIN_ID, ASSET_SYMBOL, 50, true); // skipCache=true for fresh data
+    const cache = await getCacheInterface();
+    const changes: ApyChangeEvent[] = [];
+
+    for (const vault of vaults) {
+      const cacheKey = `${CACHE_KEY_PREFIX}${vault.address}`;
+      const baselineStr = await cache.get(cacheKey);
+      const currentApy = vault.avgNetApy;
+
+      if (baselineStr) {
+        const baseline = parseFloat(baselineStr);
+        const changeAbsolute = currentApy - baseline;
+
+        if (Math.abs(changeAbsolute) >= this.threshold) {
+          changes.push({
+            vaultAddress: vault.address,
+            vaultName: vault.name,
+            previousApy: baseline,
+            currentApy,
+            changeAbsolute,
+            changeRelative: baseline > 0 ? changeAbsolute / baseline : 0,
+            direction: changeAbsolute > 0 ? 'up' : 'down',
+            timestamp: Date.now(),
+          });
+        }
+      }
+
+      // Update baseline (always keep latest)
+      await cache.set(cacheKey, currentApy.toString(), BASELINE_TTL);
+    }
+
+    if (changes.length > 0) {
+      console.log(`[APY Monitor] Detected ${changes.length} significant APY changes:`);
+      for (const change of changes) {
+        console.log(
+          `  ${change.vaultName}: ${(change.previousApy * 100).toFixed(2)}% → ${(change.currentApy * 100).toFixed(2)}% (${change.direction === 'up' ? '+' : ''}${(change.changeAbsolute * 100).toFixed(2)}%)`
+        );
+      }
+    }
+
+    return {
+      checked: vaults.length,
+      changes,
+      affectedVaults: changes.map(c => c.vaultAddress),
+    };
+  }
+
+  /**
+   * Get vaults where APY dropped significantly.
+   * These are candidates for moving funds OUT of.
+   */
+  async getDroppedVaults(): Promise<ApyChangeEvent[]> {
+    const result = await this.detectChanges();
+    return result.changes.filter(c => c.direction === 'down');
+  }
+
+  /**
+   * Get vaults where APY increased significantly.
+   * These are candidates for moving funds INTO.
+   */
+  async getImprovedVaults(): Promise<ApyChangeEvent[]> {
+    const result = await this.detectChanges();
+    return result.changes.filter(c => c.direction === 'up');
+  }
+
+  /**
+   * Reset all baselines (force fresh detection cycle)
+   */
+  async resetBaselines(): Promise<void> {
+    const cache = await getCacheInterface();
+    const vaults = await this.morphoClient.fetchVaults(CHAIN_ID, ASSET_SYMBOL, 50);
+    for (const vault of vaults) {
+      await cache.set(
+        `${CACHE_KEY_PREFIX}${vault.address}`,
+        vault.avgNetApy.toString(),
+        BASELINE_TTL,
+      );
+    }
+    console.log(`[APY Monitor] Reset baselines for ${vaults.length} vaults`);
+  }
+}

--- a/lib/oracles/chainlink.ts
+++ b/lib/oracles/chainlink.ts
@@ -1,0 +1,87 @@
+import { createPublicClient, http, parseAbi } from 'viem';
+import { base } from 'viem/chains';
+
+const CHAINLINK_USDC_USD = '0x7e860098F58bBFC8648a4311b374B1D669a2bc6B' as const;
+
+const AGGREGATOR_ABI = parseAbi([
+  'function latestRoundData() view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)',
+  'function decimals() view returns (uint8)',
+]);
+
+export interface PriceFeedResult {
+  price: number;       // USD price (e.g., 1.0001)
+  updatedAt: number;   // Unix timestamp of last update
+  isStale: boolean;    // True if data is older than staleness threshold
+  isDepegged: boolean; // True if price deviates >0.5% from $1.00
+  roundId: bigint;
+}
+
+const STALENESS_THRESHOLD = 3600; // 1 hour (Chainlink updates every ~1h for USDC/USD)
+const DEPEG_THRESHOLD = 0.005;    // 0.5% deviation from $1.00
+
+const publicClient = createPublicClient({
+  chain: base,
+  transport: http(),
+});
+
+/**
+ * Fetch latest USDC/USD price from Chainlink on Base
+ */
+export async function getUsdcPrice(): Promise<PriceFeedResult> {
+  const [roundId, answer, , updatedAt] = await publicClient.readContract({
+    address: CHAINLINK_USDC_USD,
+    abi: AGGREGATOR_ABI,
+    functionName: 'latestRoundData',
+  });
+
+  const decimals = await publicClient.readContract({
+    address: CHAINLINK_USDC_USD,
+    abi: AGGREGATOR_ABI,
+    functionName: 'decimals',
+  });
+
+  const price = Number(answer) / 10 ** Number(decimals);
+  const now = Math.floor(Date.now() / 1000);
+  const isStale = now - Number(updatedAt) > STALENESS_THRESHOLD;
+  const isDepegged = Math.abs(price - 1.0) > DEPEG_THRESHOLD;
+
+  return {
+    price,
+    updatedAt: Number(updatedAt),
+    isStale,
+    isDepegged,
+    roundId,
+  };
+}
+
+/**
+ * Pre-rebalance safety check.
+ * Returns true if it's safe to proceed with a rebalance.
+ * Blocks rebalancing if USDC is depegged or price data is stale.
+ */
+export async function isRebalanceSafe(): Promise<{ safe: boolean; reason?: string }> {
+  try {
+    const priceData = await getUsdcPrice();
+
+    if (priceData.isStale) {
+      return {
+        safe: false,
+        reason: `Chainlink USDC/USD data stale (last update: ${new Date(priceData.updatedAt * 1000).toISOString()})`,
+      };
+    }
+
+    if (priceData.isDepegged) {
+      return {
+        safe: false,
+        reason: `USDC depegged: $${priceData.price.toFixed(4)} (${((priceData.price - 1) * 100).toFixed(2)}% deviation)`,
+      };
+    }
+
+    return { safe: true };
+  } catch (error: any) {
+    return {
+      safe: false,
+      reason: `Chainlink oracle error: ${error.message}`,
+    };
+  }
+}

--- a/lib/protocols/aave-adapter.ts
+++ b/lib/protocols/aave-adapter.ts
@@ -1,0 +1,36 @@
+import type { ProtocolAdapter } from './adapter';
+import type { YieldOpportunity, Position } from '../yield-optimizer/types';
+import { getAaveOpportunities, getAavePosition, buildAaveDepositTx, buildAaveWithdrawTx } from '../yield-optimizer/protocols/aave';
+
+/**
+ * Aave V3 Protocol Adapter for Base Mainnet
+ * Implements the ProtocolAdapter interface for Aave V3 lending markets
+ */
+export class AaveAdapter implements ProtocolAdapter {
+  readonly protocol = 'aave' as const;
+  readonly name = 'Aave V3';
+  readonly enabled = true; // Now enabled on Base mainnet
+
+  async getOpportunities(): Promise<YieldOpportunity[]> {
+    return getAaveOpportunities();
+  }
+
+  async getPositions(userAddress: `0x${string}`): Promise<Position[]> {
+    const position = await getAavePosition(userAddress);
+    return position ? [position] : [];
+  }
+
+  async buildDepositCalls(amount: bigint, userAddress: `0x${string}`, _vaultAddress: `0x${string}`) {
+    const tx = buildAaveDepositTx(amount, userAddress);
+    return [
+      { to: tx.approve.to as `0x${string}`, data: tx.approve.data as `0x${string}`, value: 0n },
+      { to: tx.supply.to as `0x${string}`, data: tx.supply.data as `0x${string}`, value: 0n },
+    ];
+  }
+
+  async buildWithdrawCalls(userAddress: `0x${string}`, _vaultAddress: `0x${string}`, _shares?: bigint, assets?: bigint) {
+    const amount = assets || 0n;
+    const tx = buildAaveWithdrawTx(amount, userAddress);
+    return [{ to: tx.to as `0x${string}`, data: tx.data as `0x${string}`, value: 0n }];
+  }
+}

--- a/lib/protocols/adapter.ts
+++ b/lib/protocols/adapter.ts
@@ -1,0 +1,64 @@
+import type { YieldOpportunity, Position } from '../yield-optimizer/types';
+
+export interface ProtocolAdapter {
+  readonly protocol: 'morpho' | 'aave' | 'moonwell';
+
+  readonly name: string;
+
+  readonly enabled: boolean;
+
+  getOpportunities(): Promise<YieldOpportunity[]>;
+
+  getPositions(userAddress: `0x${string}`): Promise<Position[]>;
+
+  buildDepositCalls(
+    amount: bigint,
+    userAddress: `0x${string}`,
+    vaultAddress: `0x${string}`,
+  ): Promise<{ to: `0x${string}`; data: `0x${string}`; value: bigint }[]>;
+
+  buildWithdrawCalls(
+    userAddress: `0x${string}`,
+    vaultAddress: `0x${string}`,
+    shares?: bigint,
+    assets?: bigint,
+  ): Promise<{ to: `0x${string}`; data: `0x${string}`; value: bigint }[]>;
+}
+
+export class ProtocolRegistry {
+  private adapters: Map<string, ProtocolAdapter> = new Map();
+
+  register(adapter: ProtocolAdapter): void {
+    this.adapters.set(adapter.protocol, adapter);
+  }
+
+  get(protocol: string): ProtocolAdapter | undefined {
+    return this.adapters.get(protocol);
+  }
+
+  getAll(): ProtocolAdapter[] {
+    return Array.from(this.adapters.values());
+  }
+
+  getEnabled(): ProtocolAdapter[] {
+    return this.getAll().filter(a => a.enabled);
+  }
+
+  async getAllOpportunities(): Promise<YieldOpportunity[]> {
+    const results = await Promise.allSettled(
+      this.getEnabled().map(a => a.getOpportunities())
+    );
+    return results
+      .filter((r): r is PromiseFulfilledResult<YieldOpportunity[]> => r.status === 'fulfilled')
+      .flatMap(r => r.value);
+  }
+
+  async getAllPositions(userAddress: `0x${string}`): Promise<Position[]> {
+    const results = await Promise.allSettled(
+      this.getEnabled().map(a => a.getPositions(userAddress))
+    );
+    return results
+      .filter((r): r is PromiseFulfilledResult<Position[]> => r.status === 'fulfilled')
+      .flatMap(r => r.value);
+  }
+}

--- a/lib/protocols/moonwell-adapter.ts
+++ b/lib/protocols/moonwell-adapter.ts
@@ -1,0 +1,46 @@
+import type { ProtocolAdapter } from './adapter';
+import type { YieldOpportunity, Position } from '../yield-optimizer/types';
+import {
+  getMoonwellOpportunities,
+  getMoonwellPosition,
+  buildMoonwellDepositTx,
+  buildMoonwellWithdrawTx,
+} from '../yield-optimizer/protocols/moonwell';
+
+export class MoonwellAdapter implements ProtocolAdapter {
+  readonly protocol = 'moonwell' as const;
+  readonly name = 'Moonwell';
+  readonly enabled = true;
+
+  async getOpportunities(): Promise<YieldOpportunity[]> {
+    return getMoonwellOpportunities();
+  }
+
+  async getPositions(userAddress: `0x${string}`): Promise<Position[]> {
+    const position = await getMoonwellPosition(userAddress);
+    return position ? [position] : [];
+  }
+
+  async buildDepositCalls(
+    amount: bigint,
+    userAddress: `0x${string}`,
+    _vaultAddress: `0x${string}`,
+  ): Promise<{ to: `0x${string}`; data: `0x${string}`; value: bigint }[]> {
+    const tx = buildMoonwellDepositTx(amount, userAddress);
+    return [
+      { to: tx.approve.to as `0x${string}`, data: tx.approve.data as `0x${string}`, value: 0n },
+      { to: tx.mint.to as `0x${string}`, data: tx.mint.data as `0x${string}`, value: 0n },
+    ];
+  }
+
+  async buildWithdrawCalls(
+    userAddress: `0x${string}`,
+    _vaultAddress: `0x${string}`,
+    _shares?: bigint,
+    assets?: bigint,
+  ): Promise<{ to: `0x${string}`; data: `0x${string}`; value: bigint }[]> {
+    const amount = assets || 0n;
+    const tx = buildMoonwellWithdrawTx(amount, userAddress);
+    return [{ to: tx.to as `0x${string}`, data: tx.data as `0x${string}`, value: 0n }];
+  }
+}

--- a/lib/protocols/morpho-adapter.ts
+++ b/lib/protocols/morpho-adapter.ts
@@ -1,0 +1,44 @@
+import type { ProtocolAdapter } from './adapter';
+import type { YieldOpportunity, Position } from '../yield-optimizer/types';
+import {
+  getMorphoOpportunities,
+  getMorphoPosition,
+  buildMorphoDepositTx,
+  buildMorphoWithdrawTx,
+} from '../yield-optimizer/protocols/morpho';
+
+export class MorphoAdapter implements ProtocolAdapter {
+  readonly protocol = 'morpho' as const;
+  readonly name = 'Morpho Blue';
+  readonly enabled = true;
+
+  async getOpportunities(): Promise<YieldOpportunity[]> {
+    return getMorphoOpportunities();
+  }
+
+  async getPositions(userAddress: `0x${string}`): Promise<Position[]> {
+    return getMorphoPosition(userAddress);
+  }
+
+  async buildDepositCalls(
+    amount: bigint,
+    userAddress: `0x${string}`,
+    vaultAddress: `0x${string}`,
+  ): Promise<{ to: `0x${string}`; data: `0x${string}`; value: bigint }[]> {
+    const tx = buildMorphoDepositTx(amount, userAddress, vaultAddress);
+    return [
+      { to: tx.approve.to as `0x${string}`, data: tx.approve.data, value: 0n },
+      { to: tx.supply.to as `0x${string}`, data: tx.supply.data, value: 0n },
+    ];
+  }
+
+  async buildWithdrawCalls(
+    userAddress: `0x${string}`,
+    vaultAddress: `0x${string}`,
+    shares?: bigint,
+    assets?: bigint,
+  ): Promise<{ to: `0x${string}`; data: `0x${string}`; value: bigint }[]> {
+    const tx = buildMorphoWithdrawTx(userAddress, shares, assets, vaultAddress);
+    return [{ to: tx.to as `0x${string}`, data: tx.data, value: 0n }];
+  }
+}

--- a/lib/yield-optimizer/config.ts
+++ b/lib/yield-optimizer/config.ts
@@ -35,16 +35,16 @@ export const PROTOCOLS = {
     rewardsDistributor: "0x330eefa8a787552DC5cAd3C3cA644844B1E61DDB" as `0x${string}`,
   },
   aave: {
-    enabled: false, // Not officially published for Base Sepolia - disable until verified
+    enabled: true, // Aave V3 deployed on Base Mainnet
     name: "Aave",
-    pool: null as `0x${string}` | null,
-    aUsdc: null as `0x${string}` | null,
+    pool: "0xA238Dd80C259a72e81d7e4664a9801593F98d1c5" as `0x${string}`,
+    aUsdc: "0x4e65fE4DbA92790696d040ac24Aa414708F5c0AB" as `0x${string}`,
   },
   moonwell: {
-    enabled: false, // No Base Sepolia deployment - mainnet only
+    enabled: true,
     name: "Moonwell",
-    comptroller: null as `0x${string}` | null,
-    mUsdc: null as `0x${string}` | null,
+    comptroller: "0xfBb21d0380beE3312B33c4353c8936a0F13EF26C" as `0x${string}`,
+    mUsdc: "0xEdc817A28E8B93B03976FBd4a3dDBc9f7D176c22" as `0x${string}`,
   },
 } as const;
 

--- a/lib/yield-optimizer/protocols/moonwell.ts
+++ b/lib/yield-optimizer/protocols/moonwell.ts
@@ -1,11 +1,12 @@
-// Moonwell Protocol Integration (Base Sepolia)
+// Moonwell Protocol Integration (Base Mainnet)
 import { createPublicClient, http, encodeFunctionData } from "viem";
-import { baseSepolia } from "viem/chains";
+import { base } from "viem/chains";
 import type { YieldOpportunity, Position } from "../types";
-import { USDC_BASE_SEPOLIA } from "../types";
-import { PROTOCOLS, ESTIMATED_APYS } from "../config";
+import { PROTOCOLS } from "../config";
 
-const MOONWELL_USDC = PROTOCOLS.moonwell.mUsdc || ("0x0000000000000000000000000000000000000000" as `0x${string}`);
+// Base Mainnet addresses
+const USDC_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as `0x${string}`;
+const MOONWELL_USDC = "0xEdc817A28E8B93B03976FBd4a3dDBc9f7D176c22" as const;
 
 const MOONWELL_ABI = [
   {
@@ -46,6 +47,13 @@ const MOONWELL_ABI = [
     inputs: [],
     outputs: [{ name: "", type: "uint256" }],
   },
+  {
+    name: "getCash",
+    type: "function",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
 ] as const;
 
 const ERC20_ABI = [
@@ -61,30 +69,112 @@ const ERC20_ABI = [
 ] as const;
 
 const client = createPublicClient({
-  chain: baseSepolia,
+  chain: base,
   transport: http(),
 });
 
 export async function getMoonwellOpportunities(): Promise<YieldOpportunity[]> {
-  // Moonwell not deployed on Base Sepolia
   if (!PROTOCOLS.moonwell.enabled) {
     return [];
   }
-  return [];
+
+  try {
+    // Fetch supply rate per timestamp (Moonwell uses per-second rates)
+    const supplyRate = await client.readContract({
+      address: MOONWELL_USDC,
+      abi: MOONWELL_ABI,
+      functionName: "supplyRatePerTimestamp",
+    }) as bigint;
+
+    // Fetch available liquidity
+    const liquidity = await client.readContract({
+      address: MOONWELL_USDC,
+      abi: MOONWELL_ABI,
+      functionName: "getCash",
+    }) as bigint;
+
+    // Convert per-timestamp rate to APY: (1 + rate/1e18)^(365*24*3600) - 1
+    const ratePerSecond = Number(supplyRate) / 1e18;
+    const secondsPerYear = 365 * 24 * 3600;
+    const apy = Math.pow(1 + ratePerSecond, secondsPerYear) - 1;
+
+    return [
+      {
+        id: "moonwell-usdc-base",
+        protocol: "moonwell",
+        name: "Moonwell USDC",
+        asset: "USDC",
+        apy,
+        tvl: liquidity,
+        address: MOONWELL_USDC,
+        riskScore: 0.3, // Compound V2 fork, established protocol
+        liquidityDepth: liquidity,
+        metadata: {
+          isVault: false,
+        },
+      },
+    ];
+  } catch (error) {
+    console.error("Error fetching Moonwell opportunities:", error);
+    return [];
+  }
 }
 
-export async function getMoonwellPosition(_userAddress: `0x${string}`): Promise<Position | null> {
-  // Moonwell not deployed on Base Sepolia
+export async function getMoonwellPosition(userAddress: `0x${string}`): Promise<Position | null> {
   if (!PROTOCOLS.moonwell.enabled) {
     return null;
   }
-  return null;
+
+  try {
+    // Check cToken balance
+    const cTokenBalance = await client.readContract({
+      address: MOONWELL_USDC,
+      abi: MOONWELL_ABI,
+      functionName: "balanceOf",
+      args: [userAddress],
+    }) as bigint;
+
+    if (cTokenBalance === 0n) {
+      return null;
+    }
+
+    // Get underlying USDC amount
+    const underlyingBalance = await client.readContract({
+      address: MOONWELL_USDC,
+      abi: MOONWELL_ABI,
+      functionName: "balanceOfUnderlying",
+      args: [userAddress],
+    }) as bigint;
+
+    // Fetch current APY
+    const supplyRate = await client.readContract({
+      address: MOONWELL_USDC,
+      abi: MOONWELL_ABI,
+      functionName: "supplyRatePerTimestamp",
+    }) as bigint;
+
+    const ratePerSecond = Number(supplyRate) / 1e18;
+    const secondsPerYear = 365 * 24 * 3600;
+    const apy = Math.pow(1 + ratePerSecond, secondsPerYear) - 1;
+
+    return {
+      protocol: "moonwell",
+      vaultAddress: MOONWELL_USDC,
+      shares: cTokenBalance,
+      assets: underlyingBalance,
+      apy,
+      enteredAt: Date.now(), // Note: actual entry timestamp would require historical data
+    };
+  } catch (error) {
+    console.error("Error fetching Moonwell position:", error);
+    return null;
+  }
 }
 
 export function buildMoonwellDepositTx(amount: bigint, _userAddress: `0x${string}`) {
   return {
     approve: {
-      to: USDC_BASE_SEPOLIA,
+      to: USDC_BASE,
       value: 0n,
       data: encodeFunctionData({
         abi: ERC20_ABI,

--- a/lib/zerodev/client-secure.ts
+++ b/lib/zerodev/client-secure.ts
@@ -23,9 +23,12 @@ export interface SecureSessionKeyResult {
  * `bigint` fields (like `v`) are not JSON-serializable — convert to string.
  */
 export function serializeSignedAuth(auth: any) {
+  // Normalize v/yParity: Privy returns yParity, ZeroDev SDK may expect v (BigInt)
+  const yParity = auth.yParity ?? auth.v;
   return {
     ...auth,
-    v: auth.v != null ? auth.v.toString() : undefined,
+    v: yParity != null ? yParity.toString() : undefined,
+    yParity: yParity != null ? Number(yParity) : undefined,
     chainId: Number(auth.chainId),
     nonce: Number(auth.nonce),
   };

--- a/tests/integration/eip7702-delegation.test.ts
+++ b/tests/integration/eip7702-delegation.test.ts
@@ -118,17 +118,19 @@ describe('Kernel Client — Permission Validator Slot', () => {
     expect(depositSelector).toBe(EXPECTED_SELECTORS.DEPOSIT);
   });
 
-  test('7. Sudo fallback only used when no permissions provided', async () => {
+  test('7. No sudo policy - error thrown when no permissions provided', async () => {
     const fs = await import('fs');
     const kernelClientSource = fs.readFileSync(
       'lib/zerodev/kernel-client.ts',
       'utf-8'
     );
 
-    // Verify the conditional pattern exists:
-    // toCallPolicy when permissions.length > 0, toSudoPolicy otherwise
-    expect(kernelClientSource).toContain('params.permissions.length > 0');
-    expect(kernelClientSource).toContain('toSudoPolicy');
+    // Verify that toSudoPolicy is NOT used (security fix)
+    expect(kernelClientSource).not.toContain('toSudoPolicy');
+
+    // Verify that we throw an error when no permissions provided
+    expect(kernelClientSource).toContain('params.permissions.length === 0');
+    expect(kernelClientSource).toContain('Session key requires explicit permissions');
     expect(kernelClientSource).toContain('toCallPolicy');
   });
 });


### PR DESCRIPTION
## Summary

- **Multi-protocol adapter framework:** Unified `ProtocolAdapter` interface + registry pattern enabling dynamic protocol discovery and composition
- **Real Aave V3 & Moonwell on Base:** Replaced Sepolia testnet stubs with production implementations (Aave pool `0xA238...`, Moonwell mUSDC `0xEdc8...`), both calculating accurate APY rates
- **Chainlink USDC/USD oracle integration:** Added pre-rebalance price validation to prevent rebalancing during depeg events or stale data
- **APY event monitoring:** 5-minute polling with baseline tracking and 1% change threshold for targeted rebalance triggers
- **EIP-7702 audit fixes:** Resolved 5 critical issues — added missing `eip7702Account` param, removed unsafe sudo policy fallback, normalized `yParity` fields, added post-execution delegation verification, and replaced no-op simulation with real eth_call

## Changes

- **Protocol Adapters**: Created `lib/protocols/` with unified interface supporting async opportunity/position fetching, deposit/withdraw call building
- **Config Updates**: Enabled Aave and Moonwell in `PROTOCOLS` config with production Base mainnet addresses
- **Aave V3 Implementation**: Rewrote `lib/yield-optimizer/protocols/aave.ts` to fetch `getReserveData()`, convert RAY liquidityRate to APY, read aUSDC totalSupply for TVL
- **Moonwell Implementation**: Rewrote `lib/yield-optimizer/protocols/moonwell.ts` to read per-timestamp rates and compound annually, fetch mUSDC balance and underlying amounts
- **Oracle Integration**: Added Chainlink USDC/USD reader with depeg detection (>0.5%) and staleness checks (>1h)
- **APY Event Monitor**: New service tracking baseline APYs in Redis (24h TTL), detecting 1% changes, returning list of affected vaults for targeted rebalancing
- **Cron Route**: Added `isRebalanceSafe()` pre-flight check, returning 503 if unsafe; added `targetedVaults` query parameter for focused rebalancing
- **Decision Engine**: Added `targetedVaults` parameter with 0.1% threshold (vs 0.5% normal), prefixing reason with `[TARGETED]`
- **Kernel Client Fixes**: Added `eip7702Account = sessionKeySigner` when eip7702Auth provided, removed `toSudoPolicy` fallback (throws on empty permissions), fixed yParity deserialization
- **Client-Secure Fixes**: Normalized yParity/v serialization to handle Privy's `yParity` field
- **Rebalance Executor**: Added pre-execution delegation check, `verifyDelegationAfterExecution()` call after UserOp, replaced no-op simulation with real per-step RPC simulation
- **Integration Tests**: Updated test 7 to verify sudo policy is removed and error thrown for empty permissions