### PR TITLE
perf: Reduce Next.js build memory with serverExternalPackages and viem deduplication

### DIFF
--- a/lib/yield-optimizer/types.ts
+++ b/lib/yield-optimizer/types.ts
@@ -47,13 +47,11 @@ export interface OptimizationResult {
   amount?: bigint;
 }
 
-import { getAddress } from "viem";
-
 export const TEST_WALLET = "0x77a54c02B48fBEF00f7576D66DE2459f102e7543" as const;
 
-// Base Mainnet addresses (production) - checksummed via getAddress()
-export const USDC_BASE = getAddress("0x833589fCD6eDb6E08f4c7C32d4f71b54bdA02913");
-export const MORPHO_BLUE_BASE = getAddress("0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb");
+// Base Mainnet addresses (production) - pre-checksummed
+export const USDC_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as `0x${string}`;
+export const MORPHO_BLUE_BASE = "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb" as `0x${string}`;
 
 // Legacy alias for backwards compatibility
 export const USDC_BASE_SEPOLIA = USDC_BASE;

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,20 @@ import type { NextConfig } from "next";
 const { IgnorePlugin } = require("webpack");
 
 const nextConfig: NextConfig = {
+  serverExternalPackages: [
+    "@morpho-org/simulation-sdk",
+    "@morpho-org/blue-sdk",
+    "@morpho-org/morpho-ts",
+    "@zerodev/sdk",
+    "@zerodev/permissions",
+    "@zerodev/ecdsa-validator",
+    "@zerodev/session-key",
+    "ioredis",
+    "@privy-io/node",
+    "@neondatabase/serverless",
+    "drizzle-orm",
+    "libsodium-wrappers",
+  ],
   webpack: (config) => {
     // Exclude React Native transitive dependencies (completely unused in this EVM project)
     config.plugins.push(

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "description": "Tapioca Finance — smart yield optimization on Base with autonomous DeFi agent",
   "license": "proprietary",
   "scripts": {
-    "dev": "next dev --turbopack --experimental-https",
-    "build": "NODE_OPTIONS='--max-old-space-size=4096' next build",
+    "dev": "next dev --turbopack",
+    "build": "NODE_OPTIONS='--max-old-space-size=8192' next build",
     "start": "next start",
     "format": "prettier --write .",
     "format:check": "prettier --check .",


### PR DESCRIPTION
## Summary
- Externalize server-only packages (Morpho, ZeroDev, ioredis, etc.) so webpack skips bundling them during build, reducing peak memory consumption during compilation
- Remove viem import from yield-optimizer types to break unnecessary dependency chain that propagates through barrel exports
- Increase Node.js heap size to 8GB as safety net for builds that still approach memory limits

## Changes
- Added `serverExternalPackages` config in next.config.ts for 12 heavy dependencies (estimated 100-200MB peak memory savings)
- Replaced `getAddress()` calls with pre-checksummed address literals in lib/yield-optimizer/types.ts
- Bumped Node.js `--max-old-space-size` from 4096MB to 8192MB in build script
- Removed obsolete `--experimental-https` flag from dev script