### PR TITLE
fix: passing sessionkey instead of EOA

### DIFF
--- a/lib/zerodev/client-secure.ts
+++ b/lib/zerodev/client-secure.ts
@@ -10,6 +10,7 @@
 
 import { createPublicClient, http } from 'viem';
 import { base } from 'viem/chains';
+import { CHAIN_CONFIG } from '@/lib/yield-optimizer/config';
 
 export interface SecureSessionKeyResult {
   smartAccountAddress: `0x${string}`;
@@ -121,7 +122,7 @@ export async function checkSmartAccountActive(
   try {
     const publicClient = createPublicClient({
       chain: base,
-      transport: http(),
+      transport: http(CHAIN_CONFIG.rpcUrl),
     });
 
     const code = await publicClient.getBytecode({ address });


### PR DESCRIPTION
## Summary
- **Fixed InvalidValidator() error (0xc48cf8ee):** Root cause was passing `eip7702Account = sessionKeySigner` instead of the EOA address. The SDK converts `eip7702Account` into a sudo validator — providing the wrong address corrupted validator setup and caused vault deposits to fail.
- **Aligned with ZeroDev reference pattern:** Server-side execution now matches `deserializePermissionAccount` — passing `eip7702Auth` only (no `eip7702Account`), letting SDK use built-in `addressToEmptyAccount()` fallback. Session key signs via `plugins.regular` permission validator.
- **Verified against ZeroDev SDK source and official examples:** Delegation-active path now always passes `eip7702Auth` to maintain `isEip7702=true` for correct signing paths (ERC-1271, typed data).

## Changes
- **`lib/zerodev/kernel-client.ts`**: 
  - Removed incorrect `eip7702Account = sessionKeySigner` assignment (was causing validator corruption)
  - When delegation active: still pass `eip7702Auth` to keep `isEip7702=true` (SDK detects active delegation and skips redundant auth)
  - When delegation inactive: pass `eip7702Auth` only, let SDK use `addressToEmptyAccount()` internally
  - Added explicit error if neither delegation is active NOR auth is provided (user must re-register)
  - Fixed public client creation to use `CHAIN_CONFIG.rpcUrl` instead of rate-limited public endpoint
  - Updated comments to reference ZeroDev's `deserializePermissionAccount` pattern as authority

- **`lib/zerodev/client-secure.ts`**:
  - Fixed `checkSmartAccountActive()` to use `CHAIN_CONFIG.rpcUrl` (avoid 429 rate limit on public endpoint)