### PR TITLE
fix: sudo validator not set

### DIFF
--- a/app/api/vault/deposit/route.ts
+++ b/app/api/vault/deposit/route.ts
@@ -124,7 +124,7 @@ export async function POST(request: NextRequest) {
       smartAccountAddress: decryptedAuth.eoaAddress,
       vaultAddress,
       amount: String(amount),
-      sessionPrivateKeyPrefix: decryptedAuth.sessionPrivateKey?.slice(0, 10) + '...',
+      hasSerialized: !!decryptedAuth.serializedAccount,
       approvedVaultsCount: approvedVaults.length,
     });
 
@@ -133,7 +133,9 @@ export async function POST(request: NextRequest) {
       smartAccountAddress: decryptedAuth.eoaAddress,
       vaultAddress: vaultAddress as `0x${string}`,
       amount: String(amount),
-      sessionPrivateKey: decryptedAuth.sessionPrivateKey as `0x${string}`,
+      serializedAccount: decryptedAuth.serializedAccount,
+      // Legacy fallback fields
+      sessionPrivateKey: decryptedAuth.sessionPrivateKey as `0x${string}` | undefined,
       approvedVaults: approvedVaults as `0x${string}`[],
       eip7702SignedAuth: decryptedAuth.eip7702SignedAuth,
     });

--- a/app/api/vault/redeem/route.ts
+++ b/app/api/vault/redeem/route.ts
@@ -119,7 +119,8 @@ export async function POST(request: NextRequest) {
       vaultAddress: vaultAddress as `0x${string}`,
       shares: BigInt(shares),
       receiver: decryptedAuth.eoaAddress,
-      sessionPrivateKey: decryptedAuth.sessionPrivateKey as `0x${string}`,
+      serializedAccount: decryptedAuth.serializedAccount,
+      sessionPrivateKey: decryptedAuth.sessionPrivateKey as `0x${string}` | undefined,
       approvedVaults: approvedVaults as `0x${string}`[],
     });
 

--- a/scripts/test-encryption.ts
+++ b/scripts/test-encryption.ts
@@ -71,7 +71,7 @@ console.log(`Original sessionPrivateKey: ${agentAuth.sessionPrivateKey}`);
 console.log(`Is Encrypted: ${isAuthorizationEncrypted(agentAuth)}`);
 
 const encryptedAuth = encryptAuthorization(agentAuth);
-console.log(`Encrypted sessionPrivateKey: ${encryptedAuth.sessionPrivateKey.substring(0, 50)}...`);
+console.log(`Encrypted sessionPrivateKey: ${encryptedAuth.sessionPrivateKey?.substring(0, 50)}...`);
 console.log(`Is Encrypted: ${isAuthorizationEncrypted(encryptedAuth)}`);
 console.log(`Other fields unchanged: ${encryptedAuth.eoaAddress === agentAuth.eoaAddress ? '✓' : '✗'}`);
 

--- a/tests/helpers/test-setup.ts
+++ b/tests/helpers/test-setup.ts
@@ -309,7 +309,8 @@ export async function createTestAgentSession(
     type: 'zerodev-agent-session',
     smartAccountAddress: `0x${'e'.repeat(40)}` as `0x${string}`,
     sessionKeyAddress: `0x${'f'.repeat(40)}` as `0x${string}`,
-    sessionPrivateKey: `0x${'fedcba0987654321'.repeat(4)}` as `0x${string}`,
+    serializedAccount: `base64_test_serialized_${'a'.repeat(100)}`, // Serialized kernel account (new pattern)
+    sessionPrivateKey: `0x${'fedcba0987654321'.repeat(4)}` as `0x${string}`, // Legacy field
     expiry: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60, // 30 days
     approvedVaults: [vault1, vault2],
     timestamp: Date.now(),

--- a/tests/integration/agent-session.test.ts
+++ b/tests/integration/agent-session.test.ts
@@ -24,13 +24,14 @@ describe('Agent Session Key for Rebalancing', () => {
     await cleanupTestData([testAddress]);
   });
 
-  test('Create agent session key with sudo policy', async () => {
+  test('Create agent session key with serialized account', async () => {
     const agentAuth = await createTestAgentSession(testAddress);
 
     expect(agentAuth).toHaveProperty('type', 'zerodev-agent-session');
     expect(agentAuth).toHaveProperty('smartAccountAddress');
     expect(agentAuth).toHaveProperty('sessionKeyAddress');
-    expect(agentAuth).toHaveProperty('sessionPrivateKey');
+    expect(agentAuth).toHaveProperty('serializedAccount'); // New pattern
+    expect(agentAuth).toHaveProperty('sessionPrivateKey'); // Legacy field
     expect(agentAuth).toHaveProperty('expiry');
     expect(agentAuth).toHaveProperty('approvedVaults');
     expect(agentAuth.approvedVaults).toBeInstanceOf(Array);

--- a/tests/integration/e2e-flow.test.ts
+++ b/tests/integration/e2e-flow.test.ts
@@ -27,7 +27,7 @@ describe('End-to-End Workflows', () => {
     resetUserRateLimit(testAddress);
   });
 
-  test('Full gasless transfer flow', async () => {
+  test('Full gasless transfer flow (legacy sessionPrivateKey)', async () => {
     // Step 1: User enables gasless transfers (creates transfer session)
     const transferSession = await createTestTransferSession(testAddress);
     expect(transferSession).toBeDefined();
@@ -53,10 +53,33 @@ describe('End-to-End Workflows', () => {
     // Step 5: Recipient balance increased (would be verified on-chain)
   });
 
+  test('Full gasless transfer flow (serializedAccount)', async () => {
+    // Step 1: User enables gasless transfers with serialized kernel account
+    const transferSession = await createTestTransferSession(testAddress);
+    expect(transferSession).toBeDefined();
+
+    // Step 2: User sends $50 USDC via serialized account path
+    const transferParams = {
+      userAddress: testAddress,
+      smartAccountAddress: transferSession.smartAccountAddress,
+      recipient: recipientAddress,
+      amount: '50.00',
+      serializedAccount: 'base64_test_serialized_account_data',
+    };
+
+    const result = await executeGaslessTransfer(transferParams);
+
+    // Step 3: Transfer executes in simulation mode (serializedAccount path)
+    expect(result.success).toBe(true);
+    expect(result.hash).toBeDefined();
+    expect(result.hash).toMatch(/^0x[a-fA-F0-9]+$/);
+  });
+
   test('Full autonomous rebalancing flow', async () => {
-    // Step 1: User enables auto-optimize (creates agent session)
+    // Step 1: User enables auto-optimize (creates agent session with serialized account)
     const agentSession = await createTestAgentSession(testAddress);
     expect(agentSession).toBeDefined();
+    expect(agentSession.serializedAccount).toBeDefined(); // New pattern
     expect(agentSession.approvedVaults).toBeDefined();
     expect(agentSession.approvedVaults.length).toBeGreaterThan(0);
 

--- a/tests/integration/gasless-transfer.test.ts
+++ b/tests/integration/gasless-transfer.test.ts
@@ -142,6 +142,35 @@ describe('Gasless Transfer Execution', () => {
     expect(validation.error).toBe('Session authorization required');
   });
 
+  test('Validate transfer parameters - serializedAccount as alternative to sessionPrivateKey', () => {
+    // With serializedAccount, sessionPrivateKey is not required
+    const params = {
+      userAddress: testAddress as `0x${string}`,
+      smartAccountAddress: transferSession.smartAccountAddress,
+      recipient: recipientAddress as `0x${string}`,
+      amount: '25.00',
+      serializedAccount: 'base64_test_serialized_account',
+    };
+
+    const validation = validateTransferParams(params);
+    expect(validation.valid).toBe(true);
+    expect(validation.error).toBeUndefined();
+  });
+
+  test('Validate transfer parameters - neither serializedAccount nor sessionPrivateKey', () => {
+    const params = {
+      userAddress: testAddress as `0x${string}`,
+      smartAccountAddress: transferSession.smartAccountAddress,
+      recipient: recipientAddress as `0x${string}`,
+      amount: '25.00',
+      // No serializedAccount and no sessionPrivateKey
+    };
+
+    const validation = validateTransferParams(params);
+    expect(validation.valid).toBe(false);
+    expect(validation.error).toBe('Session authorization required');
+  });
+
   test('Transfer amounts are correctly converted to USDC decimals', async () => {
     // USDC has 6 decimals
     // "10.50" should become 10500000


### PR DESCRIPTION
## Summary
- Implement ZeroDev's official `serializePermissionAccount` / `deserializePermissionAccount` two-party pattern to fix "sudo validator not set" error
- Client creates full kernel account with EOA as sudo, serializes it (capturing enable signature), server deserializes for execution
- Update all 4 executors to support new serialized account pattern with fallback to legacy sessionPrivateKey
- Add comprehensive test coverage for serialize/deserialize pattern (9 new tests)

## Changes
- **client-secure.ts**: Added `createAndSerializeAccount()` internal function; updated `registerAgentSecure()` to accept walletClient and use serialize pattern
- **kernel-client.ts**: Added `createDeserializedKernelClient()` to reconstruct kernel account from serialized data (no sudo needed)
- **session-encryption.ts**: Added optional `serializedAccount` field to `SessionKey7702Authorization`; updated encrypt/decrypt functions
- **All 4 executors** (transfer, deposit, vault, rebalance): Added `serializedAccount` parameter support; prefer deserialized path when available with legacy fallback
- **API routes**: Updated to pass `serializedAccount` from decrypted authorization to executors
- **hooks/useOptimizer.ts**: Updated registration to create walletClient from Privy provider and pass to `registerAgentSecure`
- **generate-session-key/route.ts**: Rewritten to accept serialized account data from client instead of generating server-side
- **transfer-executor validation**: Fixed to accept `serializedAccount` as alternative to `sessionPrivateKey`
- **Test suite**: Updated 4 test files (agent-session, e2e-flow, eip7702-delegation, gasless-transfer) to cover new pattern; added 9 new tests for serialize/deserialize verification
- **Test helpers**: Added `serializedAccount` to mock agent sessions