### PR TITLE
ci: deploy only main branch

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,11 @@
       "path": "/api/agent/cron",
       "schedule": "0 12 * * *"
     }
-  ]
+  ],
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "*": false
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Restrict Vercel deployments to trigger only on the `main` branch
- Disable automatic deployments for all other branches to reduce unnecessary CI/CD runs
- Ensures production deployments are only triggered from the main branch

## Changes
- Added `git.deploymentEnabled` configuration to `vercel.json` with `main: true` and `*: false`
- Prevents preview deployments from triggering on feature branches