### PR TITLE
fix: duplicated wallet address in database

### DIFF
--- a/app/api/agent/sync/route.ts
+++ b/app/api/agent/sync/route.ts
@@ -16,18 +16,20 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Missing wallet address" }, { status: 400 });
     }
 
+    const normalizedAddress = address.toLowerCase();
+
     // 1. Ensure user record exists
     // We use ON CONFLICT DO NOTHING to avoid overwriting existing data (like 7702 authorizations)
     await sql`
       INSERT INTO users (wallet_address)
-      VALUES (${address})
+      VALUES (${normalizedAddress})
       ON CONFLICT (wallet_address) DO NOTHING
     `;
 
     // 2. Ensure user has a strategy entry
     await sql`
       INSERT INTO user_strategies (user_id)
-      SELECT id FROM users WHERE wallet_address = ${address}
+      SELECT id FROM users WHERE wallet_address = ${normalizedAddress}
       ON CONFLICT (user_id) DO NOTHING
     `;
 


### PR DESCRIPTION
## Summary
- Fixed case sensitivity bug causing duplicate wallet address entries in the database
- `/api/agent/sync` was inserting checksummed (mixed-case) addresses from Privy without lowercasing them
- PostgreSQL's case-sensitive UNIQUE constraint on `text` treated `0xAbCdEf...` and `0xabcdef...` as different values

## Changes
- Added `address.toLowerCase()` normalization in `/api/agent/sync/route.ts` before database operations
- Aligned with existing pattern used in `/api/agent/register` and `/api/agent/generate-session-key` endpoints