### PR TITLE
feat: chainlink L2 sequencer integration for safety oracle feed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -433,6 +433,11 @@ export const server = setupServer(
 **Why**: Logs may be exposed; sensitive data is at risk.  
 **Do instead**: Log only non-sensitive identifiers (userId, vaultId, operation type). Mask amounts.
 
+### ❌ Don't use `http()` without an explicit RPC URL
+
+**Why**: `http()` without a URL defaults to a rate-limited public RPC endpoint, causing 429 errors and unreliable behavior. It also bypasses the project's Alchemy RPC.
+**Do instead**: Always pass the configured RPC URL: `http(CHAIN_CONFIG.rpcUrl)`. Never use bare `http()` or interact with public RPCs when an Alchemy endpoint is available.
+
 ### ❌ Don't deploy without running tests
 
 **Why**: Tests catch breaking changes and security issues.  

--- a/lib/oracles/chainlink.ts
+++ b/lib/oracles/chainlink.ts
@@ -1,7 +1,9 @@
 import { createPublicClient, http, parseAbi } from 'viem';
 import { base } from 'viem/chains';
+import { CHAIN_CONFIG } from '@/lib/yield-optimizer/config';
 
 const CHAINLINK_USDC_USD = '0x7e860098F58bBFC8648a4311b374B1D669a2bc6B' as const;
+const BASE_SEQUENCER_UPTIME_FEED = '0xBCF85224fc0756B9Fa45aA7892530B47e10b6433' as const;
 
 const AGGREGATOR_ABI = parseAbi([
   'function latestRoundData() view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)',
@@ -16,13 +18,42 @@ export interface PriceFeedResult {
   roundId: bigint;
 }
 
-const STALENESS_THRESHOLD = 3600; // 1 hour (Chainlink updates every ~1h for USDC/USD)
-const DEPEG_THRESHOLD = 0.005;    // 0.5% deviation from $1.00
+const STALENESS_THRESHOLD = 86400; // 24 hours (matches Chainlink USDC/USD heartbeat on Base)
+const DEPEG_THRESHOLD = 0.005;     // 0.5% deviation from $1.00
+const SEQUENCER_GRACE_PERIOD = 3600; // 1 hour grace period after sequencer comes back up
 
 const publicClient = createPublicClient({
   chain: base,
-  transport: http(),
+  transport: http(CHAIN_CONFIG.rpcUrl),
 });
+
+/**
+ * Check if the Base L2 sequencer is up and has been up long enough to trust price data.
+ * Uses Chainlink's L2 Sequencer Uptime Feed.
+ * answer == 0: sequencer is up, answer == 1: sequencer is down
+ */
+async function isSequencerUp(): Promise<{ up: boolean; reason?: string }> {
+  const [, answer, startedAt] = await publicClient.readContract({
+    address: BASE_SEQUENCER_UPTIME_FEED,
+    abi: AGGREGATOR_ABI,
+    functionName: 'latestRoundData',
+  });
+
+  if (answer !== 0n) {
+    return { up: false, reason: 'Base L2 sequencer is down' };
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const timeSinceUp = now - Number(startedAt);
+  if (timeSinceUp < SEQUENCER_GRACE_PERIOD) {
+    return {
+      up: false,
+      reason: `Base L2 sequencer recently restarted (${timeSinceUp}s ago, grace period: ${SEQUENCER_GRACE_PERIOD}s)`,
+    };
+  }
+
+  return { up: true };
+}
 
 /**
  * Fetch latest USDC/USD price from Chainlink on Base
@@ -57,10 +88,15 @@ export async function getUsdcPrice(): Promise<PriceFeedResult> {
 /**
  * Pre-rebalance safety check.
  * Returns true if it's safe to proceed with a rebalance.
- * Blocks rebalancing if USDC is depegged or price data is stale.
+ * Blocks rebalancing if sequencer is down, USDC is depegged, or price data is stale.
  */
 export async function isRebalanceSafe(): Promise<{ safe: boolean; reason?: string }> {
   try {
+    const sequencerStatus = await isSequencerUp();
+    if (!sequencerStatus.up) {
+      return { safe: false, reason: sequencerStatus.reason };
+    }
+
     const priceData = await getUsdcPrice();
 
     if (priceData.isStale) {

--- a/tests/integration/chainlink-oracle.test.ts
+++ b/tests/integration/chainlink-oracle.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Chainlink Oracle Safety Check Tests
+ * Tests for USDC/USD price feed staleness, depeg detection, and L2 sequencer uptime
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+// Mock readContract responses per call
+const mockReadContract = vi.fn();
+
+vi.mock('viem', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('viem')>();
+  return {
+    ...actual,
+    createPublicClient: () => ({ readContract: mockReadContract }),
+  };
+});
+
+vi.mock('@/lib/yield-optimizer/config', () => ({
+  CHAIN_CONFIG: { rpcUrl: 'https://test-rpc.example.com', chainId: 8453, name: 'Base' },
+}));
+
+// Import after mocks are set up
+const { getUsdcPrice, isRebalanceSafe } = await import('@/lib/oracles/chainlink');
+
+// Helpers to configure mock responses
+const NOW_UNIX = Math.floor(Date.now() / 1000);
+
+function mockSequencerUp(startedAt: number = NOW_UNIX - 7200) {
+  // Sequencer: answer=0 (up), startedAt = 2 hours ago by default
+  return [1n, 0n, BigInt(startedAt), BigInt(startedAt), 1n];
+}
+
+function mockSequencerDown() {
+  return [1n, 1n, BigInt(NOW_UNIX - 100), BigInt(NOW_UNIX - 100), 1n];
+}
+
+function mockSequencerRecentRestart(secondsAgo: number = 600) {
+  // Sequencer up but restarted recently (within grace period)
+  return [1n, 0n, BigInt(NOW_UNIX - secondsAgo), BigInt(NOW_UNIX - secondsAgo), 1n];
+}
+
+function mockPriceData(price: bigint, updatedSecondsAgo: number = 3600) {
+  // latestRoundData for USDC/USD
+  return [1n, price, 0n, BigInt(NOW_UNIX - updatedSecondsAgo), 1n];
+}
+
+function mockDecimals(decimals: number = 8) {
+  return decimals;
+}
+
+describe('Chainlink Oracle Safety Checks', () => {
+  beforeEach(() => {
+    mockReadContract.mockReset();
+  });
+
+  describe('getUsdcPrice', () => {
+    test('returns correct price for healthy feed', async () => {
+      mockReadContract
+        .mockResolvedValueOnce(mockPriceData(100010000n, 1800)) // $1.0001, updated 30min ago
+        .mockResolvedValueOnce(mockDecimals(8));
+
+      const result = await getUsdcPrice();
+
+      expect(result.price).toBeCloseTo(1.0001, 4);
+      expect(result.isStale).toBe(false);
+      expect(result.isDepegged).toBe(false);
+    });
+
+    test('detects stale data (>24h old)', async () => {
+      mockReadContract
+        .mockResolvedValueOnce(mockPriceData(100000000n, 90000)) // updated 25h ago
+        .mockResolvedValueOnce(mockDecimals(8));
+
+      const result = await getUsdcPrice();
+
+      expect(result.isStale).toBe(true);
+    });
+
+    test('does not flag data updated 23h ago as stale', async () => {
+      mockReadContract
+        .mockResolvedValueOnce(mockPriceData(100000000n, 82800)) // updated 23h ago
+        .mockResolvedValueOnce(mockDecimals(8));
+
+      const result = await getUsdcPrice();
+
+      expect(result.isStale).toBe(false);
+    });
+
+    test('detects USDC depeg above 0.5%', async () => {
+      mockReadContract
+        .mockResolvedValueOnce(mockPriceData(99400000n, 1800)) // $0.994 (0.6% deviation)
+        .mockResolvedValueOnce(mockDecimals(8));
+
+      const result = await getUsdcPrice();
+
+      expect(result.isDepegged).toBe(true);
+    });
+
+    test('does not flag 0.4% deviation as depeg', async () => {
+      mockReadContract
+        .mockResolvedValueOnce(mockPriceData(99600000n, 1800)) // $0.996 (0.4% deviation)
+        .mockResolvedValueOnce(mockDecimals(8));
+
+      const result = await getUsdcPrice();
+
+      expect(result.isDepegged).toBe(false);
+    });
+  });
+
+  describe('isRebalanceSafe', () => {
+    test('returns safe when sequencer is up and price is healthy', async () => {
+      mockReadContract
+        .mockResolvedValueOnce(mockSequencerUp())         // sequencer check
+        .mockResolvedValueOnce(mockPriceData(100000000n)) // price feed
+        .mockResolvedValueOnce(mockDecimals(8));           // decimals
+
+      const result = await isRebalanceSafe();
+
+      expect(result.safe).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    test('blocks when sequencer is down', async () => {
+      mockReadContract.mockResolvedValueOnce(mockSequencerDown());
+
+      const result = await isRebalanceSafe();
+
+      expect(result.safe).toBe(false);
+      expect(result.reason).toContain('sequencer is down');
+    });
+
+    test('blocks during sequencer grace period', async () => {
+      mockReadContract.mockResolvedValueOnce(mockSequencerRecentRestart(600)); // 10min ago
+
+      const result = await isRebalanceSafe();
+
+      expect(result.safe).toBe(false);
+      expect(result.reason).toContain('recently restarted');
+      expect(result.reason).toContain('grace period');
+    });
+
+    test('allows after sequencer grace period passes', async () => {
+      mockReadContract
+        .mockResolvedValueOnce(mockSequencerUp(NOW_UNIX - 3700)) // restarted 1h+ ago
+        .mockResolvedValueOnce(mockPriceData(100000000n))
+        .mockResolvedValueOnce(mockDecimals(8));
+
+      const result = await isRebalanceSafe();
+
+      expect(result.safe).toBe(true);
+    });
+
+    test('blocks when price data is stale', async () => {
+      mockReadContract
+        .mockResolvedValueOnce(mockSequencerUp())
+        .mockResolvedValueOnce(mockPriceData(100000000n, 90000)) // 25h old
+        .mockResolvedValueOnce(mockDecimals(8));
+
+      const result = await isRebalanceSafe();
+
+      expect(result.safe).toBe(false);
+      expect(result.reason).toContain('stale');
+    });
+
+    test('blocks when USDC is depegged', async () => {
+      mockReadContract
+        .mockResolvedValueOnce(mockSequencerUp())
+        .mockResolvedValueOnce(mockPriceData(98000000n, 1800)) // $0.98
+        .mockResolvedValueOnce(mockDecimals(8));
+
+      const result = await isRebalanceSafe();
+
+      expect(result.safe).toBe(false);
+      expect(result.reason).toContain('depegged');
+    });
+
+    test('handles RPC errors gracefully', async () => {
+      mockReadContract.mockRejectedValueOnce(new Error('RPC timeout'));
+
+      const result = await isRebalanceSafe();
+
+      expect(result.safe).toBe(false);
+      expect(result.reason).toContain('RPC timeout');
+    });
+
+    test('checks sequencer before price feed (short-circuits)', async () => {
+      mockReadContract.mockResolvedValueOnce(mockSequencerDown());
+
+      await isRebalanceSafe();
+
+      // Only 1 call (sequencer) — should NOT call price feed
+      expect(mockReadContract).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed Chainlink oracle staleness threshold from 1h to 24h to match actual USDC/USD feed heartbeat on Base, unblocking rebalancing
- Added L2 sequencer uptime check (Chainlink feed) to prevent executing trades during sequencer downtime or grace period
- Fixed bare `http()` RPC call to use configured CHAIN_CONFIG.rpcUrl instead of rate-limited public endpoint

## Changes
- Increased STALENESS_THRESHOLD to 86400s (matches Chainlink's documented 24h heartbeat)
- Added isSequencerUp() function checking Base sequencer status with 3600s grace period after recovery
- Integrated sequencer check into isRebalanceSafe() with short-circuit logic (blocks before price check if down)
- Fixed publicClient transport to use CHAIN_CONFIG.rpcUrl
- Added comprehensive test suite (13 tests) covering staleness, depeg, sequencer status, grace periods, and error handling
- Updated AGENTS.md with lesson on bare http() pitfall

## Sources
- https://docs.chain.link/data-feeds/l2-sequencer-feeds 
- https://data.chain.link/feeds/base/base/usdc-usd 
- https://github.com/code-423n4/2024-07-benddao-findings/issues/24 
- https://0xmacro.com/blog/how-to-consume-chainlink-price-feeds-safely/