### PR TITLE
fix: type errors in gasless-transfer tests for CI

### DIFF
--- a/tests/integration/gasless-transfer.test.ts
+++ b/tests/integration/gasless-transfer.test.ts
@@ -81,7 +81,7 @@ describe('Gasless Transfer Execution', () => {
       sessionPrivateKey: transferSession.sessionPrivateKey,
     };
 
-    const validation = validateTransferParams(params);
+    const validation = validateTransferParams(params as any);
     expect(validation.valid).toBe(false);
     expect(validation.error).toBe('Invalid recipient address format');
   });
@@ -123,7 +123,7 @@ describe('Gasless Transfer Execution', () => {
       sessionPrivateKey: transferSession.sessionPrivateKey,
     };
 
-    const validation = validateTransferParams(params);
+    const validation = validateTransferParams(params as any);
     expect(validation.valid).toBe(false);
     expect(validation.error).toBe('Recipient address required');
   });
@@ -137,7 +137,7 @@ describe('Gasless Transfer Execution', () => {
       sessionPrivateKey: '',
     };
 
-    const validation = validateTransferParams(params);
+    const validation = validateTransferParams(params as any);
     expect(validation.valid).toBe(false);
     expect(validation.error).toBe('Session authorization required');
   });


### PR DESCRIPTION
## Summary
- Fixes 3 TypeScript errors caught by CI type check in `tests/integration/gasless-transfer.test.ts`

## Changes
- Cast intentionally invalid test params (`'invalid_address'`, `''`) with `as any` in negative validation tests where the whole point is to pass bad data to `validateTransferParams()`