### PR TITLE
feat: non-whitelisted vaults will not longer be included in investment opportunities

### DIFF
--- a/app/api/vault/redeem/route.ts
+++ b/app/api/vault/redeem/route.ts
@@ -125,11 +125,15 @@ export async function POST(request: NextRequest) {
     });
 
     if (!result.success) {
+      let userMessage = result.error || 'Vault redeem failed';
+      if (result.error?.includes('0xace2a47e')) {
+        userMessage =
+          'This vault rejected the redeem (error 0xace2a47e). ' +
+          'The vault may restrict access to agent-operated accounts. ' +
+          'Please redeem directly from your wallet.';
+      }
       console.error("[Vault Redeem] Execution failed:", result.error);
-      return NextResponse.json(
-        { error: result.error || "Vault redeem failed" },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: userMessage }, { status: 500 });
     }
 
     console.log("[Vault Redeem] Success:", result.txHash);

--- a/lib/yield-optimizer/protocols/morpho.ts
+++ b/lib/yield-optimizer/protocols/morpho.ts
@@ -257,9 +257,10 @@ export async function getMorphoOpportunities(): Promise<YieldOpportunity[]> {
     }];
   }
 
-  // Filter out vaults with RED warnings
+  // Filter out vaults with RED warnings or restricted depositor access (whitelisted: false)
   const safeVaults = vaults.filter((vault) =>
-    !vault.warnings?.some((w: any) => w.level === "RED")
+    !vault.warnings?.some((w: any) => w.level === "RED") &&
+    vault.whitelisted !== false
   );
 
   return safeVaults.map((vault) => ({


### PR DESCRIPTION
## Summary
- Filter non-whitelisted MetaMorpho vaults from investment opportunities to prevent deposits into vaults the agent cannot redeem from
- Add pre-flight vault simulation in redeem executor to catch access control failures early with clear error messages
- Translate vault access control errors (0xace2a47e) to user-friendly guidance

## Changes
- `lib/yield-optimizer/protocols/morpho.ts`: Added `vault.whitelisted !== false` condition to exclude restricted-access vaults from being included in investment targets
- `lib/zerodev/vault-executor.ts`: Added pre-flight `simulateContract` call before UserOp to detect vault-level rejections and return actionable error messages
- `app/api/vault/redeem/route.ts`: Added error translation for 0xace2a47e to guide users to redeem directly from their wallet when vault access is restricted

## Root Cause
Non-whitelisted MetaMorpho vaults enforce access control on redeem/deposit functions. The cron optimizer was depositing into these vaults, but the session key could not redeem due to access restrictions. The vault contract would reject with error 0xace2a47e (vault-specific access control error), which was opaque to users.