### PR TITLE
fix: prevent userop rate-limit exhaustion

### DIFF
--- a/lib/redis/rate-limiter.ts
+++ b/lib/redis/rate-limiter.ts
@@ -218,6 +218,29 @@ export async function getRateLimitUsage(
   }
 }
 
+const USEROP_BUDGET_KEY = (wallet: string) => `userop_budget:${wallet.toLowerCase()}`;
+
+export async function getUserOpCount(walletAddress: string): Promise<number> {
+  try {
+    const cache = await getCacheInterface();
+    const val = await cache.get(USEROP_BUDGET_KEY(walletAddress));
+    return val ? parseInt(val, 10) : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export async function incrementUserOpCount(walletAddress: string): Promise<void> {
+  try {
+    const cache = await getCacheInterface();
+    const key = USEROP_BUDGET_KEY(walletAddress);
+    const current = await cache.get(key);
+    const next = current ? parseInt(current, 10) + 1 : 1;
+    await cache.set(key, String(next), 86400);
+  } catch {
+  }
+}
+
 // ============================================
 // Transfer-specific rate limiting
 // ============================================

--- a/lib/zerodev/client-secure.ts
+++ b/lib/zerodev/client-secure.ts
@@ -150,7 +150,7 @@ async function createAndSerializeAccount(
   });
 
   const rateLimitPolicy = toRateLimitPolicy({
-    count: 10,
+    count: 90,
     interval: 86400, // 24 hours
   });
 

--- a/lib/zerodev/vault-executor.ts
+++ b/lib/zerodev/vault-executor.ts
@@ -137,9 +137,16 @@ export async function executeVaultRedeem(
 
   } catch (error: any) {
     console.error('[VaultRedeem] Execution error:', error);
+    const msg: string = error.message || '';
+    const isRateLimit =
+      msg.includes('AA23') ||
+      msg.includes('0x3e4983f6') ||
+      msg.includes('validateUserOp');
     return {
       success: false,
-      error: error.message,
+      error: isRateLimit
+        ? 'Agent daily operation limit reached. Please re-register your agent to reset the limit, or try again tomorrow.'
+        : msg,
     };
   }
 }


### PR DESCRIPTION
## Summary
- Add server-side UserOp budget tracking to prevent cron from exhausting user operation limits.
- Surface clearer rate-limit errors for redeems to guide re-registration or retry.

## Changes
- Guard cron rebalances when remaining UserOp budget is low and record successful rebalances.
- Track UserOp usage in Redis and increment on successful redeems.