### PR TITLE
fix: resolve build errors in morpho integration

### DIFF
--- a/lib/yield-optimizer/protocols/morpho-simulation.ts
+++ b/lib/yield-optimizer/protocols/morpho-simulation.ts
@@ -99,8 +99,8 @@ export function simulateSupply(
   const newState = simulateOperation(operation, simState) as SimulationState;
 
   // Calculate shares received by comparing position before/after
-  const positionBefore = simState.tryGetPosition(marketId, userAddress);
-  const positionAfter = newState.tryGetPosition(marketId, userAddress);
+  const positionBefore = simState.tryGetPosition(userAddress, marketId);
+  const positionAfter = newState.tryGetPosition(userAddress, marketId);
 
   const sharesBefore = positionBefore?.supplyShares || 0n;
   const sharesAfter = positionAfter?.supplyShares || 0n;


### PR DESCRIPTION
## Summary

- **Fixed Type Mismatches**: Corrected parameter order in `tryGetPosition` and handled nullable fields in Morpho protocol integration.
- **Reverted SDK Usage**: Reverted to using `encodeFunctionData` for Morpho Blue supply transactions as the SDK class was not available in the viem wrapper package.

## Changes

- **lib/yield-optimizer/protocols/morpho-simulation.ts**: Swapped arguments for `simState.tryGetPosition` to match correct signature `(user, marketId)`.
- **lib/yield-optimizer/protocols/morpho.ts**:
  - Reverted `buildMorphoSupplyData` to use manual ABI encoding.
  - Added null check for `vault.totalAssets` to fix `BigInt` conversion error.~