### PR TITLE
feat(legal): wire docs links and Automata AI attribution into nav + footers

### DIFF
--- a/app/(authenticated)/dashboard/layout.tsx
+++ b/app/(authenticated)/dashboard/layout.tsx
@@ -7,6 +7,7 @@ import { useAuth, useWallet } from "@/hooks/useWallet";
 import { usePrivy, useConnectWallet } from "@privy-io/react-auth";
 import { useProcessWithdrawal } from "@/hooks/useProcessWithdrawal";
 import { BottomNav } from "@/components/tapioca/BottomNav";
+import { LegalFooter } from "@/components/tapioca/LegalFooter";
 
 /**
  * Custom hook: returns true after `ms` if `active` stays true.
@@ -140,7 +141,10 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         <div className="pearl-motif absolute right-[30%] top-[40%] hidden h-20 w-20 opacity-[0.02] md:block" />
         <div className="pearl-motif absolute left-[15%] top-[85%] hidden h-12 w-12 opacity-[0.03] md:block" />
       </div>
-      <div className="relative z-10 pb-32 md:pb-12">{children}</div>
+      <div className="relative z-10 pb-32 md:pb-12">
+        {children}
+        <LegalFooter />
+      </div>
       {/* BottomNav — mobile only */}
       <div className="md:hidden">
         <BottomNav />

--- a/components/home/Footer.tsx
+++ b/components/home/Footer.tsx
@@ -1,3 +1,5 @@
+import { DOCS_LINKS, AUTOMATA_URL } from "@/lib/constants/links";
+
 export function Footer() {
   return (
     <footer className="border-[var(--pearl)]/5 relative z-10 border-t-4 py-20">
@@ -11,11 +13,18 @@ export function Footer() {
             <span className="text-2xl font-black text-[var(--pearl)]">Tapioca</span>
           </div>
 
-          {/* Center — Links (future pages, use buttons until routes exist) */}
+          {/* Center — Primary footer links (mix of future pages + live docs) */}
           <div className="text-[var(--pearl)]/60 flex flex-wrap justify-center gap-10 text-sm font-bold uppercase tracking-widest">
             <button className="transition-colors hover:text-[var(--matcha)]">Flavor Guide</button>
             <button className="transition-colors hover:text-[var(--matcha)]">Lab Tests</button>
-            <button className="transition-colors hover:text-[var(--matcha)]">Recipe Book</button>
+            <a
+              href={DOCS_LINKS.home}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="transition-colors hover:text-[var(--matcha)]"
+            >
+              Recipe Book
+            </a>
           </div>
 
           {/* Right — Social icon in dark circle (per Stitch) */}
@@ -34,8 +43,41 @@ export function Footer() {
           </div>
         </div>
 
+        {/* Legal links — smaller, above copyright */}
+        <div className="text-[var(--pearl)]/40 mt-16 flex flex-wrap justify-center gap-8 text-xs font-bold uppercase tracking-[0.2em]">
+          <a
+            href={DOCS_LINKS.terms}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition-colors hover:text-[var(--matcha)]"
+          >
+            Terms
+          </a>
+          <a
+            href={DOCS_LINKS.privacy}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition-colors hover:text-[var(--matcha)]"
+          >
+            Privacy
+          </a>
+        </div>
+
+        {/* Powered by Automata AI */}
+        <div className="text-[var(--pearl)]/40 mt-6 text-center text-[10px] font-bold uppercase tracking-[0.3em]">
+          Powered by{" "}
+          <a
+            href={AUTOMATA_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition-colors hover:text-[var(--matcha)]"
+          >
+            Automata AI
+          </a>
+        </div>
+
         {/* Copyright */}
-        <div className="text-[var(--pearl)]/30 mt-20 text-center text-xs font-black uppercase tracking-[0.4em]">
+        <div className="text-[var(--pearl)]/30 mt-3 text-center text-xs font-black uppercase tracking-[0.4em]">
           &copy; 2026 TAPIOCA FINANCE &bull; BREWED WITH LOVE
         </div>
       </div>

--- a/components/home/MobileHeader.tsx
+++ b/components/home/MobileHeader.tsx
@@ -4,10 +4,17 @@ import { useState, useCallback, useEffect } from "react";
 import { Menu, X } from "lucide-react";
 import { m, AnimatePresence } from "framer-motion";
 import { useLoginRedirect } from "@/hooks/useLoginRedirect";
+import { DOCS_LINKS, AUTOMATA_URL } from "@/lib/constants/links";
 
 const navLinks = [
   { label: "Our Menu", href: "#menu" },
   { label: "Daily Toppings", href: "#how-it-works" },
+];
+
+const legalLinks = [
+  { label: "Recipe Book", href: DOCS_LINKS.home },
+  { label: "Terms", href: DOCS_LINKS.terms },
+  { label: "Privacy", href: DOCS_LINKS.privacy },
 ];
 
 export function MobileHeader() {
@@ -160,6 +167,41 @@ export function MobileHeader() {
                 Start Sipping
               </m.button>
             </m.nav>
+
+            {/* Legal strip — pinned near bottom of overlay */}
+            <m.div
+              className="relative z-10 flex flex-col items-center gap-3 pb-10 pt-4"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1, transition: { delay: 0.3 } }}
+              exit={{ opacity: 0 }}
+            >
+              <div className="text-[var(--milktea)]/40 flex flex-wrap justify-center gap-6 text-xs font-bold uppercase tracking-[0.2em]">
+                {legalLinks.map((link) => (
+                  <a
+                    key={link.label}
+                    href={link.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={close}
+                    className="transition-colors hover:text-[var(--matcha)] active:text-[var(--matcha)]"
+                  >
+                    {link.label}
+                  </a>
+                ))}
+              </div>
+              <div className="text-[var(--milktea)]/30 text-[10px] font-bold uppercase tracking-[0.3em]">
+                Powered by{" "}
+                <a
+                  href={AUTOMATA_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={close}
+                  className="transition-colors hover:text-[var(--matcha)]"
+                >
+                  Automata AI
+                </a>
+              </div>
+            </m.div>
 
             {/* Decorative matcha glow */}
             <div className="pointer-events-none absolute -bottom-20 -right-20 h-64 w-64 rounded-full bg-[var(--matcha)] opacity-10 blur-3xl" />

--- a/components/tapioca/LegalFooter.tsx
+++ b/components/tapioca/LegalFooter.tsx
@@ -1,0 +1,50 @@
+import { DOCS_LINKS, AUTOMATA_URL } from "@/lib/constants/links";
+
+/**
+ * Minimal legal links row. Shown inside authenticated layouts where there
+ * is no marketing footer. Stays above mobile BottomNav via sufficient
+ * bottom padding on the parent container.
+ */
+export function LegalFooter() {
+  return (
+    <footer className="mx-auto mt-16 max-w-5xl px-6 pb-4 md:mt-20 md:pb-0">
+      <div className="text-[var(--pearl)]/40 flex flex-wrap items-center justify-center gap-6 text-[10px] font-bold uppercase tracking-[0.2em]">
+        <a
+          href={DOCS_LINKS.home}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="transition-colors hover:text-[var(--matcha)]"
+        >
+          Recipe Book
+        </a>
+        <a
+          href={DOCS_LINKS.terms}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="transition-colors hover:text-[var(--matcha)]"
+        >
+          Terms
+        </a>
+        <a
+          href={DOCS_LINKS.privacy}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="transition-colors hover:text-[var(--matcha)]"
+        >
+          Privacy
+        </a>
+      </div>
+      <div className="text-[var(--pearl)]/30 mt-3 text-center text-[10px] font-bold uppercase tracking-[0.3em]">
+        Powered by{" "}
+        <a
+          href={AUTOMATA_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="transition-colors hover:text-[var(--matcha)]"
+        >
+          Automata AI
+        </a>
+      </div>
+    </footer>
+  );
+}

--- a/components/tapioca/TopNav.tsx
+++ b/components/tapioca/TopNav.tsx
@@ -3,6 +3,7 @@
 import { useLoginRedirect } from "@/hooks/useLoginRedirect";
 import { PillButton } from "./PillButton";
 import { cn } from "@/lib/utils";
+import { DOCS_LINKS } from "@/lib/constants/links";
 
 interface TopNavProps {
   className?: string;
@@ -40,6 +41,14 @@ export function TopNav({ className }: TopNavProps) {
             className="text-sm font-bold text-[var(--pearl)] transition-colors hover:text-[var(--matcha)]"
           >
             Daily Toppings
+          </a>
+          <a
+            href={DOCS_LINKS.home}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-bold text-[var(--pearl)] transition-colors hover:text-[var(--matcha)]"
+          >
+            Recipe Book
           </a>
           <PillButton variant="nav" onClick={handleClick}>
             Start Sipping

--- a/lib/constants/links.ts
+++ b/lib/constants/links.ts
@@ -1,0 +1,9 @@
+export const DOCS_BASE_URL = "https://docs.tapioca.money";
+
+export const DOCS_LINKS = {
+  home: DOCS_BASE_URL,
+  terms: `${DOCS_BASE_URL}/legal/terms-and-conditions`,
+  privacy: `${DOCS_BASE_URL}/legal/privacy-policy`,
+} as const;
+
+export const AUTOMATA_URL = "https://beautomata.com";


### PR DESCRIPTION
## Summary

Wires the live documentation site and Automata AI attribution into every surface where users can reach them.

**Shared**
- `lib/constants/links.ts` — single source of truth for `DOCS_LINKS` (home, terms, privacy) and `AUTOMATA_URL`. One edit flips every surface if URLs change.

**Public marketing surfaces**
- `components/home/Footer.tsx` — converts Recipe Book from a non-functional button to a real `docs.tapioca.money` link, adds a secondary row with Terms + Privacy, and inserts "Powered by Automata AI" above the existing copyright.
- `components/home/MobileHeader.tsx` — pins a Recipe Book / Terms / Privacy strip plus a "Powered by Automata AI" line at the bottom of the fullscreen mobile menu overlay. Fades in after the main nav items, auto-closes the menu on tap.
- `components/tapioca/TopNav.tsx` — adds a Recipe Book link between "Daily Toppings" and the "Start Sipping" CTA on desktop. Terms/Privacy stay in the footer only (nav shouldn't carry legal).

**Authenticated surfaces**
- `components/tapioca/LegalFooter.tsx` — new shared component with Recipe Book / Terms / Privacy + attribution.
- `app/(authenticated)/dashboard/layout.tsx` — renders `<LegalFooter />` inside the `pb-32 md:pb-12` container so it stays clear of the fixed mobile BottomNav. Ensures logged-in users always have a visible path to legal docs (standard compliance UX).

## Link placement

| Surface | Recipe Book | Terms | Privacy | Powered by |
|---|---|---|---|---|
| Public TopNav (desktop) | yes | — | — | — |
| Public Mobile overlay | yes | yes | yes | yes |
| Public Footer | yes | yes | yes | yes |
| Dashboard LegalFooter | yes | yes | yes | yes |

All external links use `target="_blank"` + `rel="noopener noreferrer"`.

## Why

The docs site at `docs.tapioca.money` just went live (tapioca-docs PR #1 merged today). The app has no path to the live legal docs yet. Per standard compliance UX, authenticated users must also have visible legal links from the dashboard.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx prettier --check` — clean after autofix on MobileHeader
- [x] `npm run test:run` — 710 passed, 1 skipped (unrelated)
- [ ] Visual QA: landing footer, mobile burger overlay, desktop TopNav, authenticated dashboard
- [ ] Click each link → opens `docs.tapioca.money/...` in new tab
- [ ] Confirm Mobile overlay closes when tapping a legal link

🤖 Generated with [Claude Code](https://claude.com/claude-code)