### PR TITLE
feat(send): customer-paid USDC sends via ZeroDev ERC-20 paymaster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,3 +227,39 @@ jobs:
             exit 1
           fi
           pnpm db:migrate
+
+  # Trigger Vercel deploy via Deploy Hook — fires only after migrate has
+  # succeeded, guaranteeing the new schema is live before the new app code
+  # ships. Vercel's automatic git-push deploy for main is disabled in
+  # vercel.json ("deploymentEnabled.main": false), so this hook is the
+  # only way production gets built.
+  #
+  # If migrate was skipped (meta-only change), we still trigger deploy —
+  # application code changes must ship even when schema didn't move.
+  deploy:
+    name: Vercel Deploy (production)
+    needs: [migrate]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    concurrency:
+      group: vercel-deploy-production
+      cancel-in-progress: false
+    environment: production
+
+    steps:
+      - name: Trigger Vercel Deploy Hook
+        env:
+          DEPLOY_HOOK_URL: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
+        run: |
+          if [ -z "${DEPLOY_HOOK_URL}" ]; then
+            echo "::error::VERCEL_DEPLOY_HOOK_URL secret is not set"
+            exit 1
+          fi
+          # Use -f so a non-2xx response from Vercel fails the job.
+          # --retry-all-errors covers transient 5xx on Vercel's side.
+          curl -fsS --retry 3 --retry-all-errors --retry-delay 5 \
+            -X POST "${DEPLOY_HOOK_URL}" -o /tmp/deploy-response.json
+          echo "Deploy hook response:"
+          cat /tmp/deploy-response.json
+          echo "" # trailing newline for log readability

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,3 +141,89 @@ jobs:
   # Build is validated by Vercel on deploy.
   # Skipped in CI because Privy SDK validates appId against their API
   # at static page generation time, requiring a real app ID.
+
+  # Run Drizzle migrations against production DB before Vercel deploys main.
+  # Gating rules:
+  #   - push to main only (never on PRs — prevents feature branches from
+  #     mutating prod schema)
+  #   - requires typecheck + test + security to pass first
+  #   - fails the overall workflow if `pnpm db:migrate` fails, so an
+  #     operator sees the red X in GitHub before Vercel's deploy finishes.
+  #     Note: Vercel deploys run in parallel on push, so this is a
+  #     best-effort gate, not a strict pre-deploy barrier. See deliverable
+  #     notes in PR body for the Vercel-side follow-up (Deploy Hooks or
+  #     Ignored Build Step) if strict ordering is needed.
+  #   - idempotent: drizzle-kit migrate tracks applied files in
+  #     __drizzle_migrations and no-ops on reruns
+  #   - concurrency group pins to the workflow+ref so two migrate jobs
+  #     can't race (cancel-in-progress is already set at workflow level;
+  #     we use a dedicated group here that does NOT cancel, so an
+  #     in-flight migration finishes cleanly even if a new push lands).
+  migrate:
+    name: DB Migrate (production)
+    needs: [typecheck, test, security]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: db-migrate-production
+      cancel-in-progress: false
+    environment: production
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 2 # need HEAD~1 for the meta-only diff check
+
+      # Safety rail: if the push only touches drizzle/meta/** (snapshot or
+      # _journal churn) without a new SQL file under drizzle/*.sql, there's
+      # nothing to apply. Skip to avoid spurious "already applied" logs and
+      # shave a minute off the deploy. Any other file outside drizzle/
+      # still runs migrate because drizzle tracks applied files itself and
+      # re-running is a safe no-op.
+      - name: Check for migration changes
+        id: diff
+        run: |
+          CHANGED=$(git diff --name-only HEAD~1 HEAD -- drizzle/ || true)
+          echo "changed files under drizzle/:"
+          echo "$CHANGED"
+
+          SQL_CHANGED=$(echo "$CHANGED" | grep -E '^drizzle/[0-9]+_.*\.sql$' || true)
+          NON_META=$(echo "$CHANGED" | grep -vE '^drizzle/meta/' | grep -v '^$' || true)
+
+          if [ -z "$CHANGED" ]; then
+            echo "No drizzle/ changes — running migrate anyway (safe no-op)."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "$SQL_CHANGED" ] && [ -z "$NON_META" ]; then
+            echo "Only drizzle/meta/** changed and no new SQL file — skipping migrate."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "SQL or non-meta drizzle changes detected — running migrate."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        if: steps.diff.outputs.skip != 'true'
+        with:
+          version: 10
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        if: steps.diff.outputs.skip != 'true'
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        if: steps.diff.outputs.skip != 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Drizzle migrations
+        if: steps.diff.outputs.skip != 'true'
+        env:
+          DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+        run: |
+          if [ -z "${DATABASE_URL}" ]; then
+            echo "::error::PRODUCTION_DATABASE_URL secret is not set"
+            exit 1
+          fi
+          pnpm db:migrate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,28 @@ reserved for post-release hotfixes).
 
 ### Added
 
+- Send money to another wallet now works without native ETH: customer pays the gas in USDC through the ZeroDev ERC-20 paymaster. One unified send flow for Privy embedded users and external wallets, replacing the broken sponsored path.
+- Inline first-send: new users and anyone on a legacy session go through a single continuous "setting up... sending..." experience — no extra modal, one signature prompt.
+- Recipient input resolves ENS names (`vitalik.eth`) and Basenames (`luis.base.eth`) via mainnet CCIP-read with a race-safe 5-minute LRU cache; `NEXT_PUBLIC_ERPC_URL` auto-gets the `/main/evm/1` suffix.
+- Recent recipients strip on the Send screen, clipboard paste chip on focus, and a Sent! card with the actual USDC fee + BaseScan link.
+- Static "Max $500 per transfer" helper with a live "N sends remaining today" counter pulled from the new `rateLimitInfo` block on the register endpoint.
+- Redis-backed idempotency wrapper (`lib/redis/idempotency.ts`) for `/api/transfer/send`; fail-closed in production, DID-scoped keys, 60-second TTL.
+- Feature flag `NEXT_PUBLIC_ENABLE_USDC_PAYMASTER` (client) and `ENABLE_USDC_PAYMASTER` (server) for instant rollback without redeploy.
+- Migrations `0005_paymaster_version` (backfills legacy session rows with `permissionsVersion=1`) and `0006_transfer_history` (new table powering the Sent! card and recent-recipients strip).
 - Sentinel v0 circuit breaker with vault-flow signals, PagerDuty alerting, and CI/CD auto-deploy to VPS.
 - Harder Morpho vault filtering: $10M TVL floor, whitelisted-only, 50% APY cap to screen out speculative pools.
 - Paused-vault visibility on the dashboard when a user has funds in a paused vault.
 - Vault quality gates and automated review remediation.
 
+### Changed
+
+- `hooks/useWallet.ts` collapses `send` / `sendSponsored` / `enableGaslessTransfers` / `revokeGaslessTransfers` into a single phase-emitting `sendUsdc()`. Old `sendSponsored` kept as a thin shim for the test suite's migration window.
+- Transfer session CallPolicy bumped to v2: adds `USDC.approve(paymaster, ≤FEE_CAP)` with a pinned spender, so a leaked session key can never approve an arbitrary contract.
+- `createDeserializedKernelClient` accepts an optional `paymaster` option and threads it through the duplicate-permissionHash retry path — send is customer-paid, agent rebalances stay sponsored.
+
 ### Fixed
 
+- Send-to-another-wallet was effectively useless for Privy embedded users (zero native ETH → gas estimation always failed); the new paymaster flow makes the feature usable for the majority of the user base.
 - Sentinel share price normalization now uses the underlying token's `decimals()` rather than the share token's.
 - Sentinel VAULT_FLOW signal no longer pages on zero-user exits.
 - CI deploy workflow force-cleans the VPS working tree so feature-branch leftovers can't block releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ reserved for post-release hotfixes).
 - Migrations `0005_paymaster_version` (backfills legacy session rows with `permissionsVersion=1`) and `0006_transfer_history` (new table powering the Sent! card and recent-recipients strip).
 - **CI runs Drizzle migrations automatically on push to `main`**, gated behind typecheck/test/security. Uses the new `production` GitHub environment with a scoped `PRODUCTION_DATABASE_URL` secret. Safety rail skips the job when only `drizzle/meta/**` churns without a new SQL file.
 - **Vercel production deploy is now chained behind migrate via a Deploy Hook.** `vercel.json` disables main auto-deploy (`deploymentEnabled.main: false`); CI's `deploy` job POSTs to `VERCEL_DEPLOY_HOOK_URL` only after migrate succeeds. Production never ships against an un-migrated schema.
+- Regression-guard tests for the send feature's load-bearing invariants: `sendUsdc` phase emission (inline session setup, idempotency-key plumbing, error-code propagation) and CallPolicy v2 shape (paymaster-approve spender pinned via `ParamCondition.EQUAL`). 513 unit tests pass, up from 500.
 - Sentinel v0 circuit breaker with vault-flow signals, PagerDuty alerting, and CI/CD auto-deploy to VPS.
 - Harder Morpho vault filtering: $10M TVL floor, whitelisted-only, 50% APY cap to screen out speculative pools.
 - Paused-vault visibility on the dashboard when a user has funds in a paused vault.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ reserved for post-release hotfixes).
 - Redis-backed idempotency wrapper (`lib/redis/idempotency.ts`) for `/api/transfer/send`; fail-closed in production, DID-scoped keys, 60-second TTL.
 - Feature flag `NEXT_PUBLIC_ENABLE_USDC_PAYMASTER` (client) and `ENABLE_USDC_PAYMASTER` (server) for instant rollback without redeploy.
 - Migrations `0005_paymaster_version` (backfills legacy session rows with `permissionsVersion=1`) and `0006_transfer_history` (new table powering the Sent! card and recent-recipients strip).
+- **CI runs Drizzle migrations automatically on push to `main`**, gated behind typecheck/test/security. Uses the new `production` GitHub environment with a scoped `PRODUCTION_DATABASE_URL` secret. Safety rail skips the job when only `drizzle/meta/**` churns without a new SQL file.
+- **Vercel production deploy is now chained behind migrate via a Deploy Hook.** `vercel.json` disables main auto-deploy (`deploymentEnabled.main: false`); CI's `deploy` job POSTs to `VERCEL_DEPLOY_HOOK_URL` only after migrate succeeds. Production never ships against an un-migrated schema.
 - Sentinel v0 circuit breaker with vault-flow signals, PagerDuty alerting, and CI/CD auto-deploy to VPS.
 - Harder Morpho vault filtering: $10M TVL floor, whitelisted-only, 50% APY cap to screen out speculative pools.
 - Paused-vault visibility on the dashboard when a user has funds in a paused vault.

--- a/app/api/transfer/history/route.ts
+++ b/app/api/transfer/history/route.ts
@@ -1,0 +1,101 @@
+/**
+ * Transfer History API.
+ *
+ * GET /api/transfer/history?address=0x...&limit=10&unique=recipient
+ *   Returns the authenticated user's recent customer-paid sends.
+ *   `unique=recipient` dedupes by recipient address, keeping the most recent
+ *   row per recipient — used by the Recent Recipients strip.
+ *
+ * See tasks/architecture-usdc-send.md §14.3 for the data contract.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@/lib/db";
+import {
+  requireAuthForAddress,
+  unauthorizedResponse,
+  forbiddenResponse,
+} from "@/lib/auth/middleware";
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const address = searchParams.get("address");
+
+    if (!address) {
+      return NextResponse.json({ error: "Address required" }, { status: 400 });
+    }
+
+    const authResult = await requireAuthForAddress(request, address);
+    if (!authResult.authenticated) {
+      if (authResult.error === "Address does not belong to authenticated user") {
+        return forbiddenResponse(authResult.error);
+      }
+      return unauthorizedResponse(authResult.error);
+    }
+
+    const rawLimit = parseInt(searchParams.get("limit") ?? String(DEFAULT_LIMIT), 10);
+    const limit = Number.isFinite(rawLimit)
+      ? Math.min(Math.max(1, rawLimit), MAX_LIMIT)
+      : DEFAULT_LIMIT;
+    const unique = searchParams.get("unique") === "recipient";
+
+    const users = await sql`
+      SELECT id FROM users WHERE LOWER(wallet_address) = LOWER(${address})
+    `;
+    if (users.length === 0) {
+      return NextResponse.json({ history: [] });
+    }
+    const userId = users[0].id as string;
+
+    // DISTINCT ON keeps the most recent row per recipient_addr. The outer
+    // wrapper re-orders by created_at desc since DISTINCT ON orders by its
+    // first column internally.
+    const rows = unique
+      ? await sql`
+          SELECT * FROM (
+            SELECT DISTINCT ON (recipient_addr)
+              id, tx_hash, user_op_hash, recipient_addr, recipient_label,
+              amount, fee_paid, created_at
+            FROM transfer_history
+            WHERE user_id = ${userId}
+            ORDER BY recipient_addr, created_at DESC
+          ) recent
+          ORDER BY created_at DESC
+          LIMIT ${limit}
+        `
+      : await sql`
+          SELECT id, tx_hash, user_op_hash, recipient_addr, recipient_label,
+                 amount, fee_paid, created_at
+          FROM transfer_history
+          WHERE user_id = ${userId}
+          ORDER BY created_at DESC
+          LIMIT ${limit}
+        `;
+
+    return NextResponse.json({
+      history: rows.map((r) => ({
+        id: r.id,
+        txHash: r.tx_hash,
+        userOpHash: r.user_op_hash,
+        recipientAddress: r.recipient_addr,
+        recipientLabel: r.recipient_label,
+        amount: r.amount,
+        feePaid: r.fee_paid,
+        createdAt: r.created_at,
+      })),
+    });
+  } catch (error: any) {
+    console.error("[API] Transfer history fetch failed:", error);
+    return NextResponse.json(
+      {
+        error: "Internal server error",
+        ...(process.env.NODE_ENV === "development" && { details: error.message }),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/transfer/register/route.ts
+++ b/app/api/transfer/register/route.ts
@@ -21,6 +21,35 @@ import {
   unauthorizedResponse,
   forbiddenResponse,
 } from "@/lib/auth/middleware";
+import { checkRateLimit } from "@/lib/redis/rate-limiter";
+
+const DAILY_TRANSFER_LIMIT = 20;
+const DAILY_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+async function readTransferRateLimitInfo(address: string) {
+  try {
+    const r = await checkRateLimit(address, {
+      maxRequests: DAILY_TRANSFER_LIMIT,
+      windowMs: DAILY_WINDOW_MS,
+      keyPrefix: "transfer",
+      failClosed: false, // read-only probe, don't error on Redis down
+    });
+    const used = Math.max(0, DAILY_TRANSFER_LIMIT - r.remaining);
+    return {
+      used,
+      limit: DAILY_TRANSFER_LIMIT,
+      remaining: r.remaining,
+      resetAt: r.resetTime ?? Date.now() + DAILY_WINDOW_MS,
+    };
+  } catch {
+    return {
+      used: 0,
+      limit: DAILY_TRANSFER_LIMIT,
+      remaining: DAILY_TRANSFER_LIMIT,
+      resetAt: Date.now() + DAILY_WINDOW_MS,
+    };
+  }
+}
 
 /**
  * GET /api/transfer/register?address=0x...
@@ -51,10 +80,13 @@ export async function GET(request: NextRequest) {
       WHERE LOWER(wallet_address) = LOWER(${address})
     `;
 
+    const rateLimitInfo = await readTransferRateLimitInfo(address);
+
     if (users.length === 0) {
       return NextResponse.json({
         isEnabled: false,
         message: "User not found",
+        rateLimitInfo,
       });
     }
 
@@ -63,18 +95,21 @@ export async function GET(request: NextRequest) {
     if (!transferAuth) {
       return NextResponse.json({
         isEnabled: false,
+        rateLimitInfo,
       });
     }
 
-    // Validate session
     const validation = validateTransferSession(transferAuth);
-
     if (!validation.valid) {
       return NextResponse.json({
         isEnabled: false,
         reason: validation.reason,
+        rateLimitInfo,
       });
     }
+
+    // Missing field defaults to v1 — clients treat < 2 as upgrade required.
+    const permissionsVersion = transferAuth.permissionsVersion ?? 1;
 
     return NextResponse.json({
       isEnabled: true,
@@ -82,6 +117,8 @@ export async function GET(request: NextRequest) {
       sessionKeyAddress: transferAuth.sessionKeyAddress,
       expiry: transferAuth.expiry,
       createdAt: transferAuth.createdAt,
+      permissionsVersion,
+      rateLimitInfo,
     });
   } catch (error: any) {
     console.error("[API] Transfer status check failed:", error);
@@ -138,15 +175,18 @@ export async function POST(request: NextRequest) {
 
     const existingAuth = users[0].transfer_authorization as TransferSessionAuthorization | null;
 
-    // Check if valid session already exists
+    // Accept an existing session only if it's valid AND on the current CallPolicy version.
+    // Legacy v1 sessions must be re-created to include paymaster-approve permission.
     if (existingAuth) {
       const validation = validateTransferSession(existingAuth);
-      if (validation.valid) {
+      const version = existingAuth.permissionsVersion ?? 1;
+      if (validation.valid && version >= 2) {
         console.log("[API] Valid transfer session already exists");
         return NextResponse.json({
           success: true,
           smartAccountAddress: existingAuth.smartAccountAddress,
           expiry: existingAuth.expiry,
+          permissionsVersion: version,
           message: "Transfer session already active",
         });
       }
@@ -176,6 +216,7 @@ export async function POST(request: NextRequest) {
       smartAccountAddress: authorization.smartAccountAddress,
       sessionKeyAddress: authorization.sessionKeyAddress,
       expiry: authorization.expiry,
+      permissionsVersion: authorization.permissionsVersion,
     });
   } catch (error: any) {
     console.error("[API] Transfer session creation failed:", error);

--- a/app/api/transfer/send/route.ts
+++ b/app/api/transfer/send/route.ts
@@ -1,17 +1,16 @@
 /**
- * Gasless Transfer Execution API
+ * Customer-Paid Transfer Execution API
  *
- * POST /api/transfer/send - Execute gasless USDC transfer
+ * POST /api/transfer/send — Execute USDC transfer via the ERC-20 paymaster.
+ * Gas is paid by the user in USDC; Tapioca does not subsidise.
+ * See tasks/spec-usdc-send.md and tasks/architecture-usdc-send.md.
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { sql } from "@/lib/db";
+import { executeUserPaidTransfer, validateTransferParams } from "@/lib/zerodev/transfer-executor";
 import {
-  executeGaslessTransfer,
-  validateTransferParams,
-  type GaslessTransferParams,
-} from "@/lib/zerodev/transfer-executor";
-import {
+  TRANSFER_PERMISSIONS_VERSION,
   validateTransferSession,
   type TransferSessionAuthorization,
 } from "@/lib/zerodev/transfer-session";
@@ -20,6 +19,7 @@ import {
   recordTransferAttemptRedis,
   checkAndRecordRateLimit,
 } from "@/lib/redis/rate-limiter";
+import { IdempotencyBusyError, withIdempotencyKey } from "@/lib/redis/idempotency";
 import { decryptAuthorization } from "@/lib/security/session-encryption";
 import {
   requireAuthForAddress,
@@ -27,24 +27,48 @@ import {
   forbiddenResponse,
 } from "@/lib/auth/middleware";
 import { validateTransferRecipient } from "@/lib/zerodev/transfer-recipient-validator";
+import { isUsdcPaymasterEnabledServer } from "@/lib/config";
+
+interface SendResponseBody {
+  success: boolean;
+  hash?: string;
+  userOpHash?: string;
+  feePaid?: string;
+  attemptsRemaining?: number;
+  error?: string;
+  code?: string;
+}
 
 /**
  * POST /api/transfer/send
- * Execute gasless USDC transfer via ZeroDev bundler
+ * Execute customer-paid USDC transfer via ZeroDev bundler + ERC-20 paymaster.
+ * Requires the session row to have `permissionsVersion >= 2`.
  */
 export async function POST(request: NextRequest) {
   try {
+    if (!isUsdcPaymasterEnabledServer()) {
+      return NextResponse.json<SendResponseBody>(
+        { success: false, error: "Sends are temporarily disabled", code: "FEATURE_DISABLED" },
+        { status: 503 }
+      );
+    }
+
     const body = await request.json();
-    const { address, recipient, amount } = body;
+    const { address, recipient, amount, label } = body as {
+      address?: string;
+      recipient?: string;
+      amount?: string;
+      label?: string;
+    };
 
     if (!address || !recipient || !amount) {
-      return NextResponse.json(
-        { error: "Missing required fields: address, recipient, amount" },
+      return NextResponse.json<SendResponseBody>(
+        { success: false, error: "Missing required fields: address, recipient, amount" },
         { status: 400 }
       );
     }
 
-    // SECURITY: Verify authenticated user owns the sender address
+    // SECURITY: verify the authenticated user owns the sender address.
     const authResult = await requireAuthForAddress(request, address);
     if (!authResult.authenticated) {
       if (authResult.error === "Address does not belong to authenticated user") {
@@ -53,221 +77,254 @@ export async function POST(request: NextRequest) {
       return unauthorizedResponse(authResult.error);
     }
 
-    console.log("[API] Processing gasless transfer...");
-    console.log("[API] From:", address);
-    console.log("[API] To:", recipient);
-    console.log("[API] Amount:", amount, "USDC");
+    const idempotencyKey = request.headers.get("idempotency-key") ?? undefined;
 
-    // 1. Get user and transfer authorization from database
-    const users = await sql`
-      SELECT id, transfer_authorization
-      FROM users
-      WHERE LOWER(wallet_address) = LOWER(${address})
-    `;
+    const runHandler = async (): Promise<{ status: number; body: SendResponseBody }> => {
+      console.log("[API] Processing user-paid transfer...");
 
-    if (users.length === 0) {
-      return NextResponse.json({ error: "User not found" }, { status: 404 });
-    }
-
-    const encryptedAuth = users[0].transfer_authorization as TransferSessionAuthorization | null;
-
-    if (!encryptedAuth) {
-      return NextResponse.json(
-        { error: "Gasless transfers not enabled. Please enable in settings." },
-        { status: 403 }
-      );
-    }
-
-    // Decrypt authorization
-    const transferAuth = decryptAuthorization(encryptedAuth);
-
-    // 2. Validate transfer session
-    const sessionValidation = validateTransferSession(transferAuth);
-
-    if (!sessionValidation.valid) {
-      return NextResponse.json(
-        {
-          error: "Transfer session invalid or expired",
-          reason: sessionValidation.reason,
-        },
-        { status: 403 }
-      );
-    }
-
-    // 2b. SECURITY: Validate recipient address (H-3 defense-in-depth)
-    // The on-chain CallPolicy cannot constrain transfer recipients, so we
-    // enforce server-side validation: no zero address, no self-transfers,
-    // no known contract addresses (which would lose funds or enable drains).
-    const recipientValidation = validateTransferRecipient(recipient, address);
-    if (!recipientValidation.valid) {
-      // Log blocked attempt for monitoring
-      await sql`
-        INSERT INTO agent_actions (
-          user_id, action_type, status, amount_usdc, error_message, metadata
-        ) VALUES (
-          ${users[0].id}, 'transfer', 'blocked',
-          ${amount}, ${recipientValidation.reason || "Recipient validation failed"},
-          ${JSON.stringify({ recipient, reason: recipientValidation.reason })}
-        )
+      // 1. Load user + decrypt session row.
+      const users = await sql`
+        SELECT id, transfer_authorization
+        FROM users
+        WHERE LOWER(wallet_address) = LOWER(${address})
       `;
-      console.warn(
-        "[API] Transfer blocked — invalid recipient:",
-        recipient,
-        recipientValidation.reason
-      );
-      return NextResponse.json(
-        { error: recipientValidation.reason || "Invalid recipient" },
-        { status: 400 }
-      );
-    }
+      if (users.length === 0) {
+        return { status: 404, body: { success: false, error: "User not found" } };
+      }
 
-    // 2c. SECURITY: Stricter per-hour rate limit (H-3 defense-in-depth)
-    // The daily rate limit (20/day) is too coarse to prevent rapid draining.
-    // This adds a 3-transfers-per-hour limit as a tighter window.
-    const hourlyRateLimit = await checkAndRecordRateLimit(address, {
-      maxRequests: 3,
-      windowMs: 60 * 60 * 1000, // 1 hour
-      keyPrefix: "transfer_hourly",
-      failClosed: true,
-    });
-    if (!hourlyRateLimit.allowed) {
-      console.warn("[API] Transfer blocked — hourly rate limit exceeded for:", address);
-      return NextResponse.json(
-        {
-          error: "Hourly transfer limit exceeded (max 3 per hour)",
-          reason: hourlyRateLimit.reason,
-          retryAfter: hourlyRateLimit.retryAfter,
-        },
-        { status: 429 }
-      );
-    }
+      const encryptedAuth = users[0].transfer_authorization as TransferSessionAuthorization | null;
+      if (!encryptedAuth) {
+        return {
+          status: 409,
+          body: {
+            success: false,
+            error: "Session required — please complete send setup.",
+            code: "SESSION_UPGRADE_REQUIRED",
+          },
+        };
+      }
 
-    // 3. Check rate limits (daily)
-    const amountNum = parseFloat(amount);
-    const rateLimitCheck = await checkTransferRateLimitRedis(address, amountNum);
+      const transferAuth = decryptAuthorization(encryptedAuth);
 
-    if (!rateLimitCheck.allowed) {
-      return NextResponse.json(
-        {
-          error: "Rate limit exceeded",
-          reason: rateLimitCheck.reason,
-          attemptsRemaining: rateLimitCheck.remaining,
-          resetTime: rateLimitCheck.resetTime,
-        },
-        { status: 429 }
-      );
-    }
+      // 2. Version gate BEFORE any expensive work — missing field defaults to v1.
+      const storedVersion = transferAuth.permissionsVersion ?? 1;
+      if (storedVersion < TRANSFER_PERMISSIONS_VERSION) {
+        return {
+          status: 409,
+          body: {
+            success: false,
+            error: "Session out of date — please re-enable send.",
+            code: "SESSION_UPGRADE_REQUIRED",
+          },
+        };
+      }
 
-    // 4. Validate transfer parameters
-    // Prefer serializedAccount (new pattern), fall back to sessionPrivateKey (legacy)
-    const paramsValidation = validateTransferParams({
-      userAddress: address as `0x${string}`,
-      smartAccountAddress: transferAuth.smartAccountAddress,
-      recipient: recipient as `0x${string}`,
-      amount,
-      serializedAccount: transferAuth.serializedAccount,
-      sessionPrivateKey: transferAuth.sessionPrivateKey as `0x${string}` | undefined,
-    });
+      // 3. Session validity (expiry, shape).
+      const sessionValidation = validateTransferSession(transferAuth);
+      if (!sessionValidation.valid) {
+        return {
+          status: 401,
+          body: {
+            success: false,
+            error: sessionValidation.reason ?? "Session invalid",
+            code: "SESSION_EXPIRED",
+          },
+        };
+      }
 
-    if (!paramsValidation.valid) {
-      return NextResponse.json({ error: paramsValidation.error }, { status: 400 });
-    }
+      if (!transferAuth.serializedAccount) {
+        return {
+          status: 409,
+          body: {
+            success: false,
+            error: "Session storage missing — please re-enable send.",
+            code: "SESSION_UPGRADE_REQUIRED",
+          },
+        };
+      }
 
-    // 5. Execute gasless transfer
-    // Prefer serializedAccount (new pattern) — uses createDeserializedKernelClient
-    // which properly restores the on-chain permission validator.
-    // Falls back to sessionPrivateKey for legacy sessions (will warn user to re-register).
-    const transferParams: GaslessTransferParams = {
-      userAddress: address as `0x${string}`,
-      smartAccountAddress: transferAuth.smartAccountAddress,
-      recipient: recipient as `0x${string}`,
-      amount,
-      serializedAccount: transferAuth.serializedAccount,
-      sessionPrivateKey: transferAuth.sessionPrivateKey as `0x${string}` | undefined,
-    };
+      // 4. Recipient validation (H-3 defense-in-depth).
+      const recipientValidation = validateTransferRecipient(recipient, address);
+      if (!recipientValidation.valid) {
+        await sql`
+          INSERT INTO agent_actions (
+            user_id, action_type, status, amount_usdc, error_message, metadata
+          ) VALUES (
+            ${users[0].id}, 'transfer', 'blocked',
+            ${amount}, ${recipientValidation.reason || "Recipient validation failed"},
+            ${JSON.stringify({ recipient, reason: recipientValidation.reason })}
+          )
+        `;
+        return {
+          status: 400,
+          body: {
+            success: false,
+            error: recipientValidation.reason || "Invalid recipient",
+            code: "INVALID_RECIPIENT",
+          },
+        };
+      }
 
-    const result = await executeGaslessTransfer(transferParams);
+      // 5. Hourly rate-limit (tighter than daily).
+      const hourlyRateLimit = await checkAndRecordRateLimit(address, {
+        maxRequests: 3,
+        windowMs: 60 * 60 * 1000,
+        keyPrefix: "transfer_hourly",
+        failClosed: true,
+      });
+      if (!hourlyRateLimit.allowed) {
+        return {
+          status: 429,
+          body: {
+            success: false,
+            error: "Hourly transfer limit exceeded (max 3 per hour)",
+            code: "RATE_LIMIT_EXCEEDED",
+          },
+        };
+      }
 
-    // 6. Record attempt (for rate limiting)
-    await recordTransferAttemptRedis(address, amountNum, result.success);
+      // 6. Daily rate-limit.
+      const amountNum = parseFloat(amount);
+      const rateLimitCheck = await checkTransferRateLimitRedis(address, amountNum);
+      if (!rateLimitCheck.allowed) {
+        return {
+          status: 429,
+          body: {
+            success: false,
+            error: "Daily transfer limit exceeded",
+            code: "RATE_LIMIT_EXCEEDED",
+          },
+        };
+      }
 
-    // 7. Log to database
-    if (result.success) {
+      // 7. Parameter shape validation.
+      const paramsValidation = validateTransferParams({
+        userAddress: address as `0x${string}`,
+        smartAccountAddress: transferAuth.smartAccountAddress,
+        recipient: recipient as `0x${string}`,
+        amount,
+        serializedAccount: transferAuth.serializedAccount,
+      });
+      if (!paramsValidation.valid) {
+        return {
+          status: 400,
+          body: {
+            success: false,
+            error: paramsValidation.error ?? "Invalid transfer parameters",
+            code: "INVALID_PARAMS",
+          },
+        };
+      }
+
+      // 8. Execute the customer-paid transfer.
+      const result = await executeUserPaidTransfer({
+        userAddress: address as `0x${string}`,
+        smartAccountAddress: transferAuth.smartAccountAddress,
+        recipient: recipient as `0x${string}`,
+        amount,
+        serializedAccount: transferAuth.serializedAccount,
+      });
+
+      await recordTransferAttemptRedis(address, amountNum, result.success);
+
+      if (!result.success) {
+        await sql`
+          INSERT INTO agent_actions (
+            user_id, action_type, status, amount_usdc, error_message, metadata
+          ) VALUES (
+            ${users[0].id}, 'transfer', 'failed',
+            ${amount}, ${result.error || "Unknown error"},
+            ${JSON.stringify({ recipient, smartAccountAddress: transferAuth.smartAccountAddress })}
+          )
+        `;
+
+        const code = classifyBundlerError(result.error);
+        return {
+          status: code === "PAYMASTER_UNAVAILABLE" ? 503 : 500,
+          body: {
+            success: false,
+            error: result.error || "Transfer failed",
+            code,
+          },
+        };
+      }
+
+      // 9. Log to agent_actions (existing) AND fire-and-forget transfer_history insert.
       await sql`
         INSERT INTO agent_actions (
-          user_id,
-          action_type,
-          status,
-          amount_usdc,
-          tx_hash,
-          metadata
-        )
-        VALUES (
-          ${users[0].id},
-          'transfer',
-          'success',
-          ${amount},
-          ${result.hash},
+          user_id, action_type, status, amount_usdc, tx_hash, metadata
+        ) VALUES (
+          ${users[0].id}, 'transfer', 'success',
+          ${amount}, ${result.hash},
           ${JSON.stringify({
             recipient,
             userOpHash: result.userOpHash,
-            gasless: true,
+            feePaid: result.feePaid,
             smartAccountAddress: transferAuth.smartAccountAddress,
           })}
         )
       `;
 
-      console.log("[API] ✓ Transfer successful:", result.hash);
-
-      return NextResponse.json({
-        success: true,
-        hash: result.hash,
-        userOpHash: result.userOpHash,
-        attemptsRemaining: rateLimitCheck.remaining,
-      });
-    } else {
-      // Log failed attempt
-      await sql`
-        INSERT INTO agent_actions (
-          user_id,
-          action_type,
-          status,
-          amount_usdc,
-          error_message,
-          metadata
+      sql`
+        INSERT INTO transfer_history (
+          user_id, tx_hash, user_op_hash, recipient_addr, recipient_label, amount, fee_paid
+        ) VALUES (
+          ${users[0].id}, ${result.hash}, ${result.userOpHash ?? null},
+          ${recipient}, ${label ?? null}, ${amount}, ${result.feePaid ?? null}
         )
-        VALUES (
-          ${users[0].id},
-          'transfer',
-          'failed',
-          ${amount},
-          ${result.error || "Unknown error"},
-          ${JSON.stringify({
-            recipient,
-            smartAccountAddress: transferAuth.smartAccountAddress,
-          })}
-        )
-      `;
+      `.catch((err) => console.error("[TransferHistory] insert failed (non-fatal)", err));
 
-      console.error("[API] ✗ Transfer failed:", result.error);
-
-      return NextResponse.json(
-        {
-          success: false,
-          error: result.error || "Transfer failed",
+      return {
+        status: 200,
+        body: {
+          success: true,
+          hash: result.hash,
+          userOpHash: result.userOpHash,
+          feePaid: result.feePaid,
+          attemptsRemaining: rateLimitCheck.remaining,
         },
-        { status: 500 }
-      );
+      };
+    };
+
+    // Wrap in idempotency if the client supplied a key.
+    let outcome: { status: number; body: SendResponseBody };
+    if (idempotencyKey) {
+      const userScope = authResult.userId ?? address.toLowerCase();
+      try {
+        outcome = await withIdempotencyKey(userScope, idempotencyKey, runHandler);
+      } catch (err) {
+        if (err instanceof IdempotencyBusyError) {
+          return NextResponse.json<SendResponseBody>(
+            { success: false, error: err.message, code: "IDEMPOTENCY_BUSY" },
+            { status: 409 }
+          );
+        }
+        throw err;
+      }
+    } else {
+      outcome = await runHandler();
     }
+
+    return NextResponse.json<SendResponseBody>(outcome.body, { status: outcome.status });
   } catch (error: any) {
-    console.error("[API] Gasless transfer error:", error);
-    return NextResponse.json(
+    console.error("[API] User-paid transfer error:", error);
+    return NextResponse.json<SendResponseBody>(
       {
         success: false,
         error: "Internal server error",
-        ...(process.env.NODE_ENV === "development" && { details: error.message }),
+        ...(process.env.NODE_ENV === "development" && { error: error.message }),
       },
       { status: 500 }
     );
   }
+}
+
+/** Map raw bundler/paymaster error strings to user-facing error codes. */
+function classifyBundlerError(raw: string | undefined): string {
+  if (!raw) return "TRANSFER_FAILED";
+  const msg = raw.toLowerCase();
+  if (msg.includes("aa31") || msg.includes("paymaster deposit")) return "PAYMASTER_UNAVAILABLE";
+  if (msg.includes("aa23") || msg.includes("aa24")) return "SESSION_UPGRADE_REQUIRED";
+  if (msg.includes("session_upgrade_required")) return "SESSION_UPGRADE_REQUIRED";
+  return "TRANSFER_FAILED";
 }

--- a/components/send-funds/OrderPreview.tsx
+++ b/components/send-funds/OrderPreview.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { Details } from "../common/Details";
 import { PrimaryButton } from "../common/PrimaryButton";
-import { isEmail } from "@/lib/utils";
 import { shortenAddress } from "@/utils/shortenAddress";
+import { FEE_DISPLAY_USDC } from "@/lib/config";
 
 interface OrderPreviewProps {
   userEmail: string;
-  recipient: string;
+  /** Human-readable recipient label (ENS/Basename). Falls back to shortened address. */
+  recipientLabel: string | null;
+  recipientAddress: string;
   amount: string;
   error: string | null;
   isLoading: boolean;
@@ -15,12 +17,19 @@ interface OrderPreviewProps {
 
 export function OrderPreview({
   userEmail,
-  recipient,
+  recipientLabel,
+  recipientAddress,
   amount,
   error,
   isLoading,
   onConfirm,
 }: OrderPreviewProps) {
+  const numericAmount = Number(amount || "0");
+  const feeDisplay = Number(FEE_DISPLAY_USDC);
+  const total = (numericAmount + feeDisplay).toFixed(2);
+  const shortAddr = shortenAddress(recipientAddress);
+  const recipientValue = recipientLabel ? `${recipientLabel} (${shortAddr})` : shortAddr;
+
   return (
     <div className="flex w-full flex-grow flex-col justify-between">
       <div>
@@ -28,15 +37,23 @@ export function OrderPreview({
         <Details
           values={[
             { label: "From", value: userEmail },
-            { label: "To", value: isEmail(recipient) ? recipient : shortenAddress(recipient) },
-            { label: "Amount", value: `$ ${amount}` },
+            { label: "To", value: recipientValue },
+            { label: "Amount", value: `$${numericAmount.toFixed(2)}` },
+            {
+              label: "Network fee",
+              value: `~$${feeDisplay.toFixed(2)} USDC`,
+            },
+            { label: "Total", value: `$${total}` },
           ]}
         />
-        {error && <div className="mb-2 text-center text-red-500">{error}</div>}
+        <p className="text-muted-foreground mt-3 text-center text-xs">
+          Network fees are paid in USDC and deducted at confirmation.
+        </p>
+        {error && <div className="mt-3 text-center text-sm text-red-500">{error}</div>}
       </div>
       <div>
         <PrimaryButton onClick={onConfirm} disabled={isLoading}>
-          {isLoading ? "Sending..." : `Send $ ${amount}`}
+          {isLoading ? "Sending..." : `Send $${numericAmount.toFixed(2)}`}
         </PrimaryButton>
       </div>
     </div>

--- a/components/send-funds/PasteChip.tsx
+++ b/components/send-funds/PasteChip.tsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useState } from "react";
+import { ClipboardPaste } from "lucide-react";
+import { isAddress } from "viem";
+import { shortenAddress } from "@/utils/shortenAddress";
+
+interface PasteChipProps {
+  visible: boolean;
+  onPaste: (value: string) => void;
+}
+
+function looksLikeName(input: string): boolean {
+  return /^[^\s]+\.[^\s]+$/.test(input) && !input.startsWith("0x");
+}
+
+function isCandidate(input: string): boolean {
+  if (!input) return false;
+  const trimmed = input.trim();
+  if (trimmed.length > 128) return false;
+  return isAddress(trimmed) || looksLikeName(trimmed);
+}
+
+/**
+ * Offers a one-tap paste when the clipboard contains a valid recipient
+ * (0x address, ENS name, or Basename). Respects browser permission rules:
+ * - Chromium/Firefox desktop: auto-reads on visible=true.
+ * - Safari / iOS: clipboard read requires a direct user gesture, so we
+ *   render a generic "Paste from clipboard" button that reads on tap.
+ */
+export function PasteChip({ visible, onPaste }: PasteChipProps) {
+  const [suggestion, setSuggestion] = useState<string | null>(null);
+  const [needsGesture, setNeedsGesture] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!visible) {
+      setSuggestion(null);
+      setNeedsGesture(false);
+      return;
+    }
+
+    (async () => {
+      try {
+        if (typeof navigator === "undefined" || !navigator.clipboard?.readText) {
+          setNeedsGesture(true);
+          return;
+        }
+        const text = await navigator.clipboard.readText();
+        if (cancelled) return;
+        if (isCandidate(text)) {
+          setSuggestion(text.trim());
+          setNeedsGesture(false);
+        } else {
+          setSuggestion(null);
+          setNeedsGesture(false);
+        }
+      } catch {
+        // Permission denied / needs gesture.
+        if (!cancelled) setNeedsGesture(true);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [visible]);
+
+  const handleTapWithGesture = async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      if (isCandidate(text)) {
+        onPaste(text.trim());
+      }
+    } catch {
+      // User declined; no-op.
+    }
+  };
+
+  if (!visible) return null;
+
+  if (suggestion) {
+    const short = isAddress(suggestion) ? shortenAddress(suggestion) : suggestion;
+    return (
+      <button
+        type="button"
+        onClick={() => onPaste(suggestion)}
+        className="mb-2 inline-flex items-center gap-2 rounded-lg bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-700 hover:bg-blue-100"
+      >
+        <ClipboardPaste className="h-3.5 w-3.5" />
+        Paste {short}
+      </button>
+    );
+  }
+
+  if (needsGesture) {
+    return (
+      <button
+        type="button"
+        onClick={handleTapWithGesture}
+        className="mb-2 inline-flex items-center gap-2 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50"
+      >
+        <ClipboardPaste className="h-3.5 w-3.5" />
+        Paste from clipboard
+      </button>
+    );
+  }
+
+  return null;
+}

--- a/components/send-funds/RecentRecipients.tsx
+++ b/components/send-funds/RecentRecipients.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
+import { shortenAddress } from "@/utils/shortenAddress";
+
+interface RecipientRow {
+  recipientAddress: string;
+  recipientLabel: string | null;
+  createdAt: string;
+}
+
+interface RecentRecipientsProps {
+  address?: string;
+  onPick: (recipient: { address: string; label: string | null }) => void;
+}
+
+export function RecentRecipients({ address, onPick }: RecentRecipientsProps) {
+  const { data } = useQuery({
+    queryKey: ["transfer-history", "recent", address],
+    queryFn: async (): Promise<RecipientRow[]> => {
+      if (!address) return [];
+      const res = await fetch(
+        `/api/transfer/history?address=${address}&limit=3&unique=recipient`
+      );
+      const body = await res.json();
+      return body?.history ?? [];
+    },
+    enabled: !!address,
+    staleTime: 60 * 1000,
+  });
+
+  const rows = data ?? [];
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="mb-3 w-full">
+      <div className="mb-2 text-xs font-medium text-gray-500">Recent</div>
+      <div className="flex gap-2 overflow-x-auto pb-1">
+        {rows.map((row) => {
+          const label = row.recipientLabel || shortenAddress(row.recipientAddress);
+          const initial = (row.recipientLabel || row.recipientAddress).slice(0, 2).toUpperCase();
+          return (
+            <button
+              key={row.recipientAddress}
+              type="button"
+              onClick={() =>
+                onPick({ address: row.recipientAddress, label: row.recipientLabel })
+              }
+              className="flex min-w-[72px] shrink-0 flex-col items-center rounded-xl border border-gray-200 px-3 py-2 hover:border-gray-300"
+            >
+              <div className="mb-1 flex h-8 w-8 items-center justify-center rounded-full bg-gray-100 text-xs font-semibold text-gray-700">
+                {initial}
+              </div>
+              <div className="max-w-[80px] truncate text-xs text-gray-700">{label}</div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/send-funds/RecipientInput.tsx
+++ b/components/send-funds/RecipientInput.tsx
@@ -1,31 +1,141 @@
+import React, { useEffect, useId, useRef, useState } from "react";
+import { Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useId } from "react";
+import { resolveRecipient } from "@/lib/ens/resolver";
+import { shortenAddress } from "@/utils/shortenAddress";
+import { PasteChip } from "./PasteChip";
+
+export interface ResolvedRecipient {
+  /** Raw user-typed string (ENS/Basename or 0x hex). */
+  input: string;
+  /** Checksummed 0x address, or null while unresolved/invalid. */
+  address: `0x${string}` | null;
+  /** Human-readable label when the input was a name; null otherwise. */
+  label: string | null;
+  /** True while resolution is in flight. */
+  resolving: boolean;
+  /** Resolution error code when resolution fails. */
+  errorCode: "ENS_RESOLUTION_FAILED" | "INVALID_INPUT" | null;
+}
 
 interface RecipientInputProps {
-  recipient: string;
-  onChange: (recipient: string) => void;
+  value: ResolvedRecipient;
+  onChange: (next: ResolvedRecipient) => void;
   error?: string | null;
 }
 
-export function RecipientInput({ recipient, onChange, error }: RecipientInputProps) {
+const RESOLVE_DEBOUNCE_MS = 400;
+
+export function RecipientInput({ value, onChange, error }: RecipientInputProps) {
   const id = useId();
+  const [isFocused, setFocused] = useState(false);
+  const resolveSeq = useRef(0);
+
+  // Debounced resolver: race-safe via sequence tag (discard stale responses).
+  useEffect(() => {
+    const input = value.input.trim();
+    if (!input) {
+      if (value.address || value.resolving || value.errorCode) {
+        onChange({ input: value.input, address: null, label: null, resolving: false, errorCode: null });
+      }
+      return;
+    }
+
+    // 0x fast path — resolve synchronously.
+    if (/^0x[a-fA-F0-9]{40}$/.test(input)) {
+      if (value.address?.toLowerCase() !== input.toLowerCase() || value.resolving) {
+        // Let the resolver handle checksum, but update optimistically.
+        onChange({
+          input: value.input,
+          address: input as `0x${string}`,
+          label: null,
+          resolving: true,
+          errorCode: null,
+        });
+      }
+    }
+
+    const seq = ++resolveSeq.current;
+    const timer = setTimeout(async () => {
+      const result = await resolveRecipient(input);
+      if (seq !== resolveSeq.current) return; // stale
+      if ("resolved" in result) {
+        onChange({
+          input: value.input,
+          address: result.resolved,
+          label: result.label ?? null,
+          resolving: false,
+          errorCode: null,
+        });
+      } else {
+        onChange({
+          input: value.input,
+          address: null,
+          label: null,
+          resolving: false,
+          errorCode: result.error,
+        });
+      }
+    }, RESOLVE_DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+    // Intentionally exclude `onChange` / `value` (other fields) to avoid re-debouncing on every keystroke side effect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value.input]);
+
+  const handleTextChange = (text: string) => {
+    onChange({ input: text, address: null, label: null, resolving: true, errorCode: null });
+  };
+
+  const handlePaste = (pasted: string) => {
+    handleTextChange(pasted);
+  };
+
+  const resolvedAddressForDisplay =
+    value.address && value.label ? shortenAddress(value.address) : null;
+
+  const showNotFound = !!value.input.trim() && !value.resolving && value.errorCode === "ENS_RESOLUTION_FAILED";
+
   return (
     <div className="w-full">
       <label htmlFor={id} className="mb-2 block text-sm font-semibold text-gray-900">
-        Receipient
+        Recipient
       </label>
-      <input
-        id={id}
-        type="text"
-        placeholder="Enter email or wallet address"
-        className={cn(
-          "focus:border-primary h-12 w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none",
-          error && "border-red-600"
+
+      <PasteChip visible={isFocused && !value.input} onPaste={handlePaste} />
+
+      <div className="relative">
+        <input
+          id={id}
+          type="text"
+          placeholder="Address, ENS (luis.eth), or Basename"
+          className={cn(
+            "focus:border-primary h-12 w-full rounded-xl border border-gray-200 px-4 py-3 pr-10 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none",
+            (error || showNotFound) && "border-red-600"
+          )}
+          value={value.input}
+          onChange={(e) => handleTextChange(e.target.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          autoComplete="off"
+          spellCheck={false}
+        />
+        {value.resolving && (
+          <Loader2 className="text-muted-foreground absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin" />
         )}
-        value={recipient}
-        onChange={(e) => onChange(e.target.value)}
-      />
-      {error && <div className="mt-1.5 text-sm text-red-600">{error}</div>}
+      </div>
+
+      {resolvedAddressForDisplay && (
+        <div className="text-muted-foreground mt-1.5 text-xs">
+          Resolved: <span className="font-mono">{resolvedAddressForDisplay}</span>
+        </div>
+      )}
+      {showNotFound && (
+        <div className="mt-1.5 text-sm text-red-600">
+          Couldn't resolve this name. Try the wallet address.
+        </div>
+      )}
+      {error && !showNotFound && <div className="mt-1.5 text-sm text-red-600">{error}</div>}
     </div>
   );
 }

--- a/components/send-funds/SendProgress.tsx
+++ b/components/send-funds/SendProgress.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { SendPhase } from "@/hooks/useWallet";
+import { shortenAddress } from "@/utils/shortenAddress";
+
+interface SendProgressProps {
+  phase: Exclude<SendPhase, "success" | "error">;
+  userOpHash?: string;
+}
+
+const PHASE_COPY: Record<SendProgressProps["phase"], { title: string; subtitle: string; pct: number }> = {
+  submitting: {
+    title: "Submitting…",
+    subtitle: "Sending your request",
+    pct: 25,
+  },
+  signing_session: {
+    title: "Setting up…",
+    subtitle: "One-time approval to enable sending",
+    pct: 40,
+  },
+  registering: {
+    title: "Setting up…",
+    subtitle: "Saving your send settings",
+    pct: 60,
+  },
+  confirming: {
+    title: "Confirming on Base…",
+    subtitle: "Waiting for the transaction to land",
+    pct: 85,
+  },
+};
+
+export function SendProgress({ phase, userOpHash }: SendProgressProps) {
+  const { title, subtitle, pct } = PHASE_COPY[phase];
+
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center px-4 text-center">
+      <Loader2 className="mb-4 h-10 w-10 animate-spin text-blue-600" />
+      <h3 className="mb-1 text-lg font-semibold text-gray-900">{title}</h3>
+      <p className="text-muted-foreground text-sm">{subtitle}</p>
+
+      <div className="mt-6 w-full max-w-xs">
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-100">
+          <div
+            className={cn(
+              "bg-primary h-full rounded-full transition-all duration-500 ease-out"
+            )}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      </div>
+
+      {userOpHash && phase === "confirming" && (
+        <p className="text-muted-foreground mt-4 font-mono text-xs">
+          userOp {shortenAddress(userOpHash)}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/send-funds/TxSuccess.tsx
+++ b/components/send-funds/TxSuccess.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { CheckCircle2, ExternalLink } from "lucide-react";
+import { PrimaryButton } from "../common/PrimaryButton";
+import { shortenAddress } from "@/utils/shortenAddress";
+
+interface TxSuccessProps {
+  amount: string;
+  recipientAddress: string;
+  recipientLabel?: string | null;
+  txHash: string;
+  feePaid?: string;
+  onDone: () => void;
+}
+
+export function TxSuccess({
+  amount,
+  recipientAddress,
+  recipientLabel,
+  txHash,
+  feePaid,
+  onDone,
+}: TxSuccessProps) {
+  const displayFee = feePaid && Number(feePaid) > 0 ? `$${Number(feePaid).toFixed(4)}` : "—";
+  const explorerUrl = `https://basescan.org/tx/${txHash}`;
+
+  return (
+    <div className="flex flex-1 flex-col items-center justify-between px-4 pb-4 pt-8 text-center">
+      <div className="flex flex-col items-center">
+        <CheckCircle2 className="mb-3 h-12 w-12 text-green-500" />
+        <h3 className="mb-2 text-xl font-semibold text-gray-900">Sent!</h3>
+        <p className="text-sm text-gray-600">
+          ${Number(amount).toFixed(2)} USDC to{" "}
+          <span className="font-medium text-gray-900">
+            {recipientLabel || shortenAddress(recipientAddress)}
+          </span>
+        </p>
+
+        <dl className="mt-6 w-full max-w-xs space-y-2 rounded-xl border border-gray-200 p-4 text-left text-sm">
+          <div className="flex justify-between">
+            <dt className="text-gray-500">Network fee</dt>
+            <dd className="font-medium text-gray-900">{displayFee} USDC</dd>
+          </div>
+          <div className="flex justify-between">
+            <dt className="text-gray-500">Transaction</dt>
+            <dd>
+              <a
+                href={explorerUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary inline-flex items-center gap-1 font-medium hover:underline"
+              >
+                {shortenAddress(txHash)}
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      <div className="w-full pt-6">
+        <PrimaryButton onClick={onDone}>Done</PrimaryButton>
+      </div>
+    </div>
+  );
+}

--- a/components/send-funds/index.tsx
+++ b/components/send-funds/index.tsx
@@ -1,64 +1,79 @@
 import React, { useReducer, useCallback } from "react";
-import { useAuth, useWallet } from "@/hooks/useWallet";
+import { useAuth, useWallet, type SendPhase } from "@/hooks/useWallet";
 import { AmountInput } from "../common/AmountInput";
 import { OrderPreview } from "./OrderPreview";
-import { RecipientInput } from "./RecipientInput";
+import { RecipientInput, type ResolvedRecipient } from "./RecipientInput";
+import { RecentRecipients } from "./RecentRecipients";
+import { SendProgress } from "./SendProgress";
+import { TxSuccess } from "./TxSuccess";
 import { useBalance } from "@/hooks/useBalance";
 import { Dialog, DialogContent, DialogTitle, DialogClose } from "../common/Dialog";
 import { useActivityFeed } from "@/hooks/useActivityFeed";
-import { isEmail, isValidAddress } from "@/lib/utils";
-import { ArrowLeft, X, Zap, AlertTriangle } from "lucide-react";
+import { ArrowLeft, AlertTriangle } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { isUsdcPaymasterEnabled } from "@/lib/config";
 
 interface SendState {
-  recipient: string;
+  recipient: ResolvedRecipient;
   amount: string;
   showPreview: boolean;
-  isLoading: boolean;
+  phase: SendPhase | "idle";
+  userOpHash: string | null;
+  txHash: string | null;
+  feePaid: string | null;
   error: string | null;
-  gaslessOverride: boolean | null; // null = use default (gaslessEnabled), true/false = user toggled
-  gaslessLoading: boolean;
+  errorCode: string | null;
 }
 
 type SendAction =
-  | { type: "SET_RECIPIENT"; value: string }
+  | { type: "SET_RECIPIENT"; value: ResolvedRecipient }
   | { type: "SET_AMOUNT"; value: string }
-  | { type: "SET_ERROR"; error: string | null }
+  | { type: "SET_ERROR"; error: string | null; code?: string | null }
   | { type: "SHOW_PREVIEW" }
-  | { type: "START_LOADING" }
-  | { type: "STOP_LOADING" }
-  | { type: "TOGGLE_GASLESS"; value: boolean }
-  | { type: "SET_GASLESS_LOADING"; value: boolean }
+  | { type: "BACK_TO_FORM" }
+  | { type: "PHASE"; phase: SendPhase; userOpHash?: string; txHash?: string; feePaid?: string }
   | { type: "RESET" };
 
+const emptyRecipient: ResolvedRecipient = {
+  input: "",
+  address: null,
+  label: null,
+  resolving: false,
+  errorCode: null,
+};
+
 const initialState: SendState = {
-  recipient: "",
+  recipient: emptyRecipient,
   amount: "",
   showPreview: false,
-  isLoading: false,
+  phase: "idle",
+  userOpHash: null,
+  txHash: null,
+  feePaid: null,
   error: null,
-  gaslessOverride: null,
-  gaslessLoading: false,
+  errorCode: null,
 };
 
 function sendReducer(state: SendState, action: SendAction): SendState {
   switch (action.type) {
     case "SET_RECIPIENT":
-      return { ...state, recipient: action.value };
+      return { ...state, recipient: action.value, error: null, errorCode: null };
     case "SET_AMOUNT":
-      return { ...state, amount: action.value };
+      return { ...state, amount: action.value, error: null };
     case "SET_ERROR":
-      return { ...state, error: action.error };
+      return { ...state, error: action.error, errorCode: action.code ?? null };
     case "SHOW_PREVIEW":
       return { ...state, showPreview: true, error: null };
-    case "START_LOADING":
-      return { ...state, isLoading: true, error: null };
-    case "STOP_LOADING":
-      return { ...state, isLoading: false };
-    case "TOGGLE_GASLESS":
-      return { ...state, gaslessOverride: action.value };
-    case "SET_GASLESS_LOADING":
-      return { ...state, gaslessLoading: action.value };
+    case "BACK_TO_FORM":
+      return { ...state, showPreview: false, phase: "idle", error: null, errorCode: null };
+    case "PHASE":
+      return {
+        ...state,
+        phase: action.phase,
+        userOpHash: action.userOpHash ?? state.userOpHash,
+        txHash: action.txHash ?? state.txHash,
+        feePaid: action.feePaid ?? state.feePaid,
+      };
     case "RESET":
       return initialState;
   }
@@ -73,28 +88,27 @@ export function SendFundsModal({ open, onClose }: SendFundsModalProps) {
   const { wallet, isSolanaWallet } = useWallet();
   const { user } = useAuth();
   const [state, dispatch] = useReducer(sendReducer, initialState);
+  const queryClient = useQueryClient();
 
   const { displayableBalance, refetch: refetchBalance } = useBalance();
   const { refetch: refetchActivityFeed } = useActivityFeed();
-  const queryClient = useQueryClient();
 
-  // Check gasless transfer session status
-  const { data: gaslessStatus } = useQuery({
-    queryKey: ["gasless-status", wallet?.address],
+  const flagEnabled = isUsdcPaymasterEnabled();
+
+  // Load rate-limit info for the limits helper copy.
+  const { data: statusData } = useQuery({
+    queryKey: ["transfer-status", wallet?.address],
     queryFn: async () => {
       if (!wallet?.address) return null;
-      const response = await fetch(`/api/transfer/register?address=${wallet.address}`);
-      return response.json();
+      const res = await fetch(`/api/transfer/register?address=${wallet.address}`);
+      return res.json();
     },
-    enabled: !!wallet?.address && open,
+    enabled: !!wallet?.address && open && flagEnabled,
   });
 
-  const gaslessEnabled = gaslessStatus?.isEnabled ?? false;
-  const sessionExpiry = gaslessStatus?.expiry ?? null;
-  // Derive gasless toggle: user override wins, otherwise default to enabled status
-  const useGasless = state.gaslessOverride ?? gaslessEnabled;
+  const rateLimit = statusData?.rateLimitInfo;
 
-  const isRecipientValid = isValidAddress(state.recipient) || isEmail(state.recipient);
+  const isRecipientValid = !!state.recipient.address && !state.recipient.resolving;
   const isAmountValid =
     !!state.amount &&
     !Number.isNaN(Number(state.amount)) &&
@@ -103,84 +117,95 @@ export function SendFundsModal({ open, onClose }: SendFundsModalProps) {
   const canContinue = isRecipientValid && isAmountValid;
 
   const handleContinue = useCallback(() => {
-    if (isEmail(state.recipient) && !state.recipient) {
-      dispatch({ type: "SET_ERROR", error: "Please enter a recipient" });
+    if (!state.recipient.address) {
+      dispatch({ type: "SET_ERROR", error: "Enter a valid recipient" });
       return;
     }
     dispatch({ type: "SHOW_PREVIEW" });
-  }, [state.recipient]);
+  }, [state.recipient.address]);
 
   const handleSend = useCallback(async () => {
-    dispatch({ type: "START_LOADING" });
+    if (!wallet) {
+      dispatch({ type: "SET_ERROR", error: "No wallet connected" });
+      return;
+    }
+    if (!state.recipient.address || !state.amount) {
+      dispatch({ type: "SET_ERROR", error: "Invalid recipient or amount" });
+      return;
+    }
+
     try {
-      if (!isRecipientValid || !state.amount || !isAmountValid) {
-        dispatch({ type: "SET_ERROR", error: "Invalid recipient or amount" });
-        dispatch({ type: "STOP_LOADING" });
-        return;
-      }
-
-      if (!wallet) {
-        dispatch({ type: "SET_ERROR", error: "No wallet connected" });
-        dispatch({ type: "STOP_LOADING" });
-        return;
-      }
-
-      // Email recipients not supported with Privy - only wallet addresses
-      if (isEmail(state.recipient)) {
-        dispatch({
-          type: "SET_ERROR",
-          error: "Email recipients not yet supported. Please use a wallet address.",
-        });
-        dispatch({ type: "STOP_LOADING" });
-        return;
-      }
-
-      // Use gasless or regular transaction based on toggle
-      if (useGasless && gaslessEnabled) {
-        await wallet.sendSponsored(state.recipient, "USDC", state.amount);
-      } else {
-        await wallet.send(state.recipient, "usdc", state.amount);
-      }
+      const result = await wallet.sendUsdc(
+        {
+          to: state.recipient.address,
+          amount: state.amount,
+          label: state.recipient.label ?? undefined,
+        },
+        (ctx) =>
+          dispatch({
+            type: "PHASE",
+            phase: ctx.phase,
+            userOpHash: ctx.userOpHash,
+            txHash: ctx.txHash,
+            feePaid: ctx.feePaid,
+          })
+      );
 
       refetchBalance();
       refetchActivityFeed();
-      dispatch({ type: "RESET" });
-      onClose();
-    } catch (err: any) {
-      dispatch({ type: "SET_ERROR", error: err.message });
-    } finally {
-      dispatch({ type: "STOP_LOADING" });
-    }
-  }, [
-    isRecipientValid,
-    isAmountValid,
-    state.recipient,
-    state.amount,
-    wallet,
-    useGasless,
-    gaslessEnabled,
-    refetchBalance,
-    refetchActivityFeed,
-    onClose,
-  ]);
+      queryClient.invalidateQueries({ queryKey: ["transfer-history"] });
+      queryClient.invalidateQueries({ queryKey: ["transfer-status", wallet.address] });
 
-  const resetFlow = useCallback(() => dispatch({ type: "RESET" }), []);
+      dispatch({
+        type: "PHASE",
+        phase: "success",
+        txHash: result.hash,
+        feePaid: result.feePaid,
+      });
+    } catch (err: any) {
+      const code = err?.code || "TRANSFER_FAILED";
+      const message = err?.message || "Transfer failed";
+      dispatch({ type: "PHASE", phase: "error" });
+      dispatch({ type: "SET_ERROR", error: message, code });
+    }
+  }, [wallet, state.recipient, state.amount, refetchBalance, refetchActivityFeed, queryClient]);
 
   const handleDone = useCallback(() => {
     dispatch({ type: "RESET" });
     onClose();
   }, [onClose]);
 
-  const displayableAmount = Number(state.amount).toFixed(2);
-  const showBackButton = state.showPreview && !state.isLoading;
-  const showCloseButton = !state.showPreview;
+  const handleRecentPick = useCallback(
+    (pick: { address: string; label: string | null }) => {
+      dispatch({
+        type: "SET_RECIPIENT",
+        value: {
+          input: pick.label ?? pick.address,
+          address: pick.address as `0x${string}`,
+          label: pick.label,
+          resolving: false,
+          errorCode: null,
+        },
+      });
+    },
+    []
+  );
+
+  const isWorking =
+    state.phase === "submitting" ||
+    state.phase === "signing_session" ||
+    state.phase === "registering" ||
+    state.phase === "confirming";
+
+  const showBackButton = state.showPreview && state.phase === "idle";
+  const showCloseButton = !state.showPreview && state.phase === "idle";
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && handleDone()}>
       <DialogContent className="flex h-[580px] max-h-[85vh] flex-col rounded-3xl bg-white sm:max-w-md">
         {showBackButton && (
           <button
-            onClick={resetFlow}
+            onClick={() => dispatch({ type: "BACK_TO_FORM" })}
             className="absolute left-6 top-6 flex h-8 w-8 items-center justify-center rounded-full bg-gray-100 hover:bg-gray-200"
             aria-label="Back"
             type="button"
@@ -190,9 +215,24 @@ export function SendFundsModal({ open, onClose }: SendFundsModalProps) {
         )}
         {showCloseButton && <DialogClose />}
         <DialogTitle className="text-center">
-          {state.showPreview ? "Order Confirmation" : "Send"}
+          {state.phase === "success"
+            ? "Sent"
+            : state.showPreview
+              ? "Order Confirmation"
+              : "Send"}
         </DialogTitle>
-        {isSolanaWallet ? (
+
+        {!flagEnabled ? (
+          <div className="flex flex-1 flex-col items-center justify-center px-4 text-center">
+            <AlertTriangle className="mb-3 h-10 w-10 text-yellow-500" />
+            <h3 className="mb-2 text-lg font-semibold text-gray-800">
+              Sends are temporarily disabled
+            </h3>
+            <p className="text-muted-foreground text-sm">
+              We're turning this feature back on shortly. Try again in a few minutes.
+            </p>
+          </div>
+        ) : isSolanaWallet ? (
           <div className="flex flex-1 flex-col items-center justify-center px-4">
             <AlertTriangle className="mb-3 h-10 w-10 text-yellow-500" />
             <h3 className="mb-2 text-lg font-semibold text-yellow-800">
@@ -203,6 +243,20 @@ export function SendFundsModal({ open, onClose }: SendFundsModalProps) {
               wallet to send funds.
             </p>
           </div>
+        ) : state.phase === "success" && state.txHash ? (
+          <TxSuccess
+            amount={state.amount}
+            recipientAddress={state.recipient.address ?? ""}
+            recipientLabel={state.recipient.label}
+            txHash={state.txHash}
+            feePaid={state.feePaid ?? undefined}
+            onDone={handleDone}
+          />
+        ) : isWorking ? (
+          <SendProgress
+            phase={state.phase as Exclude<SendPhase, "success" | "error">}
+            userOpHash={state.userOpHash ?? undefined}
+          />
         ) : !state.showPreview ? (
           <div className="flex w-full flex-1 flex-col">
             <div className="mb-2 flex w-full flex-col items-center">
@@ -219,85 +273,23 @@ export function SendFundsModal({ open, onClose }: SendFundsModalProps) {
               >
                 Current balance: ${displayableBalance}
               </div>
+              <div className="text-muted-foreground mt-1 text-xs">
+                Max $500 per transfer
+                {rateLimit && rateLimit.remaining <= 3 && (
+                  <> · {rateLimit.remaining} sends remaining today</>
+                )}
+              </div>
             </div>
+
             <div className="mt-4 w-full">
+              <RecentRecipients address={wallet?.address} onPick={handleRecentPick} />
               <RecipientInput
-                recipient={state.recipient}
-                onChange={(v) => dispatch({ type: "SET_RECIPIENT", value: v })}
+                value={state.recipient}
+                onChange={(next) => dispatch({ type: "SET_RECIPIENT", value: next })}
                 error={state.error}
               />
             </div>
-            <div className="mt-4 w-full">
-              {gaslessEnabled ? (
-                <div className="flex items-center justify-between rounded-lg border border-gray-200 p-4">
-                  <div className="flex flex-col">
-                    <div className="flex items-center gap-2">
-                      <Zap className="h-4 w-4 text-yellow-500" />
-                      <label htmlFor="gasless-toggle" className="text-sm font-medium text-gray-900">
-                        Gasless Transaction
-                      </label>
-                    </div>
-                    <p className="text-xs text-gray-500">
-                      No ETH needed - ZeroDev sponsors gas fees
-                    </p>
-                    {sessionExpiry && (
-                      <p className="mt-1 text-xs text-gray-400">
-                        Session expires: {new Date(sessionExpiry * 1000).toLocaleDateString()}
-                      </p>
-                    )}
-                  </div>
-                  <button
-                    id="gasless-toggle"
-                    type="button"
-                    onClick={() => dispatch({ type: "TOGGLE_GASLESS", value: !useGasless })}
-                    className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                      useGasless ? "bg-blue-600" : "bg-gray-300"
-                    }`}
-                  >
-                    <span
-                      className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                        useGasless ? "translate-x-6" : "translate-x-1"
-                      }`}
-                    />
-                  </button>
-                </div>
-              ) : (
-                <button
-                  type="button"
-                  onClick={async () => {
-                    dispatch({ type: "SET_GASLESS_LOADING", value: true });
-                    dispatch({ type: "SET_ERROR", error: null });
-                    try {
-                      if (!wallet?.enableGaslessTransfers) {
-                        dispatch({ type: "SET_ERROR", error: "Gasless transfers not available" });
-                        return;
-                      }
-                      await wallet.enableGaslessTransfers();
-                      await queryClient.invalidateQueries({
-                        queryKey: ["gasless-status", wallet?.address],
-                      });
-                    } catch (err: any) {
-                      dispatch({
-                        type: "SET_ERROR",
-                        error: err.message || "Failed to enable gasless transfers",
-                      });
-                    } finally {
-                      dispatch({ type: "SET_GASLESS_LOADING", value: false });
-                    }
-                  }}
-                  disabled={state.gaslessLoading}
-                  className="w-full rounded-lg border-2 border-dashed border-blue-300 bg-blue-50 p-4 hover:bg-blue-100 disabled:opacity-50"
-                >
-                  <div className="flex items-center justify-center gap-2">
-                    <Zap className="h-5 w-5 text-blue-600" />
-                    <span className="text-sm font-medium text-blue-900">
-                      {state.gaslessLoading ? "Enabling..." : "Enable Gasless Transfers"}
-                    </span>
-                  </div>
-                  <p className="mt-1 text-xs text-blue-700">Send USDC without paying gas fees</p>
-                </button>
-              )}
-            </div>
+
             <div className="mt-auto w-full pt-8">
               <button
                 disabled={!canContinue}
@@ -311,10 +303,11 @@ export function SendFundsModal({ open, onClose }: SendFundsModalProps) {
         ) : (
           <OrderPreview
             userEmail={user?.email || ""}
-            recipient={state.recipient}
-            amount={displayableAmount}
+            recipientAddress={state.recipient.address ?? ""}
+            recipientLabel={state.recipient.label}
+            amount={state.amount}
             error={state.error}
-            isLoading={state.isLoading}
+            isLoading={isWorking}
             onConfirm={handleSend}
           />
         )}

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -133,3 +133,36 @@ export const sentinelVaultStatus = pgTable(
   },
   (table) => [index("idx_status_last_check").on(table.lastCheckAt)]
 );
+
+/**
+ * Transfer history: one row per successful customer-paid USDC send.
+ * Populated by /api/transfer/send after receipt parsing (fire-and-forget).
+ * Read by /api/transfer/history for recent recipients + send log.
+ * See tasks/spec-usdc-send.md §14.4.
+ */
+export const transferHistory = pgTable(
+  "transfer_history",
+  {
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    txHash: text("tx_hash").notNull(),
+    userOpHash: text("user_op_hash"),
+    recipientAddr: text("recipient_addr").notNull(), // checksummed 0x
+    recipientLabel: text("recipient_label"), // ENS/Basename if user typed one (cosmetic only)
+    amount: numeric("amount", { precision: 20, scale: 6 }).notNull(),
+    feePaid: numeric("fee_paid", { precision: 20, scale: 6 }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_transfer_history_user_created").on(table.userId, table.createdAt),
+    index("idx_transfer_history_user_recipient_created").on(
+      table.userId,
+      table.recipientAddr,
+      table.createdAt
+    ),
+  ]
+);

--- a/drizzle/0005_paymaster_version.sql
+++ b/drizzle/0005_paymaster_version.sql
@@ -1,0 +1,10 @@
+-- Paymaster CallPolicy version stamp (Option 2 customer-paid sends).
+-- Backfills existing transfer_authorization rows so the server can
+-- distinguish legacy v1 sessions (transfer-only) from v2 sessions
+-- (transfer + paymaster-approve). Idempotent: the `?` test guards re-runs.
+-- See tasks/spec-usdc-send.md §7.1 and architecture §5.
+
+UPDATE users
+SET transfer_authorization = transfer_authorization || '{"permissionsVersion": 1}'::jsonb
+WHERE transfer_authorization IS NOT NULL
+  AND NOT (transfer_authorization ? 'permissionsVersion');

--- a/drizzle/0006_transfer_history.sql
+++ b/drizzle/0006_transfer_history.sql
@@ -1,0 +1,23 @@
+-- Transfer history: one row per successful customer-paid USDC send.
+-- Populated by /api/transfer/send after receipt parsing (fire-and-forget —
+-- a failed insert does not fail the user-facing response). Read by
+-- /api/transfer/history for the "recent recipients" strip and tx list.
+-- See tasks/spec-usdc-send.md §14.4.
+
+CREATE TABLE IF NOT EXISTS transfer_history (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  tx_hash         TEXT NOT NULL,
+  user_op_hash    TEXT,
+  recipient_addr  TEXT NOT NULL,           -- checksummed 0x
+  recipient_label TEXT,                    -- ENS/Basename if input was one (cosmetic only)
+  amount          NUMERIC(20, 6) NOT NULL, -- USDC amount sent
+  fee_paid        NUMERIC(20, 6),          -- actual paymaster fee; null if parse failed
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_transfer_history_user_created
+  ON transfer_history (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_transfer_history_user_recipient_created
+  ON transfer_history (user_id, recipient_addr, created_at DESC);

--- a/hooks/useWallet.ts
+++ b/hooks/useWallet.ts
@@ -16,6 +16,58 @@ import { base } from "viem/chains";
 import { useMemo, useCallback } from "react";
 import { USDC_ADDRESS } from "@/lib/config";
 
+/**
+ * Phase events emitted by the new paymaster-backed USDC send flow.
+ * See tasks/architecture-usdc-send.md §8 for the full state machine.
+ */
+export type SendPhase =
+  | "submitting"
+  | "signing_session"
+  | "registering"
+  | "confirming"
+  | "success"
+  | "error";
+
+export interface SendPhaseContext {
+  phase: SendPhase;
+  userOpHash?: string;
+  txHash?: string;
+  feePaid?: string;
+  errorCode?: string;
+  errorMessage?: string;
+}
+
+export interface SendUsdcArgs {
+  to: string;
+  amount: string;
+  /** Optional ENS/Basename label for history row (cosmetic only). */
+  label?: string;
+  /** Optional client-provided idempotency key; generated when absent. */
+  idempotencyKey?: string;
+}
+
+export interface SendUsdcResult {
+  hash: string;
+  userOpHash?: string;
+  feePaid?: string;
+}
+
+function randomIdempotencyKey(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export class SendError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "SendError";
+    this.code = code;
+  }
+}
+
 // Minimal ERC-20 ABI for balance and transfer
 const erc20Abi = [
   {
@@ -168,48 +220,116 @@ export function useWallet() {
       },
 
       /**
-       * Send tokens gaslessly (ZeroDev sponsored)
-       * Uses transfer-only session key for USDC transfers
-       * No gas fees required from user
+       * Send USDC via the ERC-20 paymaster (customer-paid).
+       *
+       * Inline-handles the session lifecycle: if no session exists or the
+       * stored `permissionsVersion < 2`, the hook triggers registration
+       * transparently (FR-25) before submitting. The caller sees a single
+       * continuous stream of `SendPhase` events — no modal, no retry loop.
+       *
+       * @throws SendError with a `code` field from the error catalog.
        */
-      async sendSponsored(to: string, asset: string, amount: string) {
-        if (!address) throw new Error("Wallet address not yet available");
+      async sendUsdc(args: SendUsdcArgs, onPhase?: (ctx: SendPhaseContext) => void): Promise<SendUsdcResult> {
+        if (!address) throw new SendError("NO_WALLET", "Wallet address not yet available");
+        if (!wallet) throw new SendError("NO_WALLET", "Wallet not ready");
 
-        if (asset !== "USDC") {
-          throw new Error("Only USDC gasless transfers supported");
-        }
-
-        // Get access token for authenticated request
         const accessToken = await getAccessToken();
-        if (!accessToken) {
-          throw new Error("Authentication required for gasless transfers");
+        if (!accessToken) throw new SendError("UNAUTHENTICATED", "Authentication required");
+
+        const idempotencyKey = args.idempotencyKey ?? randomIdempotencyKey();
+        const emit = (ctx: SendPhaseContext) => {
+          try {
+            onPhase?.(ctx);
+          } catch (err) {
+            console.error("[useWallet] onPhase callback threw:", err);
+          }
+        };
+
+        emit({ phase: "submitting" });
+
+        // 1. Check session status — inline-upgrade if needed.
+        const statusRes = await fetch(`/api/transfer/register?address=${address}`, {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+        const status = await statusRes.json();
+
+        // Missing `permissionsVersion` means legacy v1 — treat as needing setup.
+        // Matches server-side gating in /api/transfer/send.
+        const storedVersion =
+          typeof status?.permissionsVersion === "number" ? status.permissionsVersion : 1;
+        const needsSetup = !status?.isEnabled || storedVersion < 2;
+
+        if (needsSetup) {
+          emit({ phase: "signing_session" });
+          const regRes = await fetch("/api/transfer/register", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${accessToken}`,
+            },
+            body: JSON.stringify({
+              address,
+              privyWallet: {
+                address: wallet.address,
+                getEthereumProvider: wallet.getEthereumProvider.bind(wallet),
+              },
+            }),
+          });
+          const regBody = await regRes.json();
+          emit({ phase: "registering" });
+          if (!regBody?.success) {
+            const code = "SESSION_SETUP_FAILED";
+            const message = regBody?.error || "Could not set up sending";
+            emit({ phase: "error", errorCode: code, errorMessage: message });
+            throw new SendError(code, message);
+          }
         }
 
-        // Check if user has transfer session key
-        const statusResponse = await fetch(`/api/transfer/register?address=${address}`);
-        const status = await statusResponse.json();
+        emit({ phase: "submitting" });
 
-        if (!status.isEnabled) {
-          throw new Error("Gasless transfers not enabled. Please enable in settings first.");
-        }
-
-        // Execute gasless transfer with authentication
-        const response = await fetch("/api/transfer/send", {
+        // 2. Submit the send (receipt waited server-side, synchronous response).
+        const sendRes = await fetch("/api/transfer/send", {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${accessToken}`,
+            "Idempotency-Key": idempotencyKey,
           },
-          body: JSON.stringify({ address, recipient: to, amount }),
+          body: JSON.stringify({ address, recipient: args.to, amount: args.amount, label: args.label }),
         });
+        const body = await sendRes.json();
 
-        const result = await response.json();
+        if (!sendRes.ok || !body?.success) {
+          const code = body?.code || "TRANSFER_FAILED";
+          const message = body?.error || "Transfer failed";
 
-        if (!result.success) {
-          throw new Error(result.error || "Gasless transfer failed");
+          // Defensive: if server flagged upgrade-required after we already
+          // ran setup, fall through to error (retry is a user-driven action).
+          emit({ phase: "error", errorCode: code, errorMessage: message });
+          throw new SendError(code, message);
         }
 
-        return result.hash;
+        if (body.userOpHash) {
+          emit({ phase: "confirming", userOpHash: body.userOpHash });
+        }
+
+        emit({
+          phase: "success",
+          txHash: body.hash,
+          userOpHash: body.userOpHash,
+          feePaid: body.feePaid,
+        });
+
+        return { hash: body.hash, userOpHash: body.userOpHash, feePaid: body.feePaid };
+      },
+
+      /**
+       * @deprecated Use `sendUsdc`. Left for tests/migration window.
+       * Routes through the new paymaster-backed flow, discarding phase events.
+       */
+      async sendSponsored(to: string, _asset: string, amount: string) {
+        const { hash } = await (this as any).sendUsdc({ to, amount });
+        return hash;
       },
 
       /**

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,7 +1,35 @@
 // Yield Optimizer Configuration
 // Protocol addresses for Base Mainnet (Production)
 
-import { getAddress } from "viem";
+import { getAddress, parseUnits } from "viem";
+import { ZERODEV_USDC_PAYMASTER_BASE } from "@/lib/zerodev/constants";
+
+/**
+ * Customer-paid USDC send via ZeroDev ERC-20 paymaster.
+ * See tasks/spec-usdc-send.md §14 for rationale.
+ */
+export const USDC_PAYMASTER_ADDRESS = ZERODEV_USDC_PAYMASTER_BASE;
+
+/** Display-only fee shown in the send preview ("~$0.05 USDC"). */
+export const FEE_DISPLAY_USDC = "0.05";
+
+/** Hard ceiling on the per-send `USDC.approve(paymaster, …)` call. */
+export const FEE_CAP_USDC = parseUnits("0.20", 6); // 200_000n
+
+/** Per-transfer USDC ceiling; mirrors transfer-session CallPolicy. */
+export const MAX_USDC_PER_TRANSFER = parseUnits("500", 6);
+
+/** Client-side feature flag helper. Reads NEXT_PUBLIC_ENABLE_USDC_PAYMASTER, defaults ON. */
+export function isUsdcPaymasterEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_ENABLE_USDC_PAYMASTER !== "false";
+}
+
+/** Server-side feature flag helper. Reads ENABLE_USDC_PAYMASTER OR the public flag, defaults ON. */
+export function isUsdcPaymasterEnabledServer(): boolean {
+  const server = process.env.ENABLE_USDC_PAYMASTER;
+  if (server != null) return server !== "false";
+  return process.env.NEXT_PUBLIC_ENABLE_USDC_PAYMASTER !== "false";
+}
 
 // Note: Custom address registration not needed - SDK uses market params directly
 // The Morpho Blue SDK will use the explicit market params we provide

--- a/lib/ens/cache.ts
+++ b/lib/ens/cache.ts
@@ -1,0 +1,61 @@
+/**
+ * Tiny LRU cache for ENS / Basename resolutions.
+ * 50 entries, 5-minute TTL (see tasks/architecture-usdc-send.md §11).
+ * Kept intentionally dependency-free; this lib is imported into the client bundle.
+ */
+
+export interface LRUOptions {
+  max?: number;
+  ttlMs?: number;
+}
+
+interface Entry<V> {
+  value: V;
+  expiresAt: number;
+}
+
+export class LRU<V> {
+  private readonly max: number;
+  private readonly ttlMs: number;
+  private readonly map = new Map<string, Entry<V>>();
+
+  constructor(opts: LRUOptions = {}) {
+    this.max = opts.max ?? 50;
+    this.ttlMs = opts.ttlMs ?? 5 * 60 * 1000;
+  }
+
+  get(key: string): V | undefined {
+    const entry = this.map.get(key);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.map.delete(key);
+      return undefined;
+    }
+    // Refresh recency.
+    this.map.delete(key);
+    this.map.set(key, entry);
+    return entry.value;
+  }
+
+  set(key: string, value: V): void {
+    if (this.map.has(key)) this.map.delete(key);
+    this.map.set(key, { value, expiresAt: Date.now() + this.ttlMs });
+    if (this.map.size > this.max) {
+      // Evict oldest.
+      const firstKey = this.map.keys().next().value;
+      if (firstKey !== undefined) this.map.delete(firstKey);
+    }
+  }
+
+  delete(key: string): void {
+    this.map.delete(key);
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+}

--- a/lib/ens/resolver.ts
+++ b/lib/ens/resolver.ts
@@ -1,0 +1,99 @@
+/**
+ * ENS + Basename recipient resolver (client-side only).
+ *
+ * Resolves `0x…` hex (identity passthrough), `*.eth`, and `*.base.eth` names
+ * to a checksummed 0x address. Basenames resolve through the same ENS
+ * machinery via CCIP-read on a mainnet provider.
+ *
+ * The resolved label is cosmetic only — the server re-validates the 0x hex
+ * on every write. See tasks/architecture-usdc-send.md §11.
+ */
+
+import { createPublicClient, getAddress, http, isAddress } from "viem";
+import { normalize } from "viem/ens";
+import { mainnet } from "viem/chains";
+import { LRU } from "./cache";
+
+export type ResolveSuccess = {
+  resolved: `0x${string}`;
+  label?: string;
+};
+
+export type ResolveFailure = {
+  error: "ENS_RESOLUTION_FAILED" | "INVALID_INPUT";
+};
+
+export type ResolveResult = ResolveSuccess | ResolveFailure;
+
+const cache = new LRU<ResolveSuccess>();
+
+const MAINNET_CHAIN_ID = 1;
+
+/**
+ * Resolve the mainnet RPC URL with eRPC-aware suffixing.
+ * - If NEXT_PUBLIC_ERPC_URL is set, append `/main/evm/1` unless it's already
+ *   a direct provider URL (Alchemy/Infura/etc.) or already has the suffix.
+ * - Pattern mirrors `sentinel/signals/onchain.ts:getClient()`.
+ * - Returns `undefined` to let viem fall back to its public endpoint.
+ */
+function mainnetRpcUrl(): string | undefined {
+  const base = process.env.NEXT_PUBLIC_ERPC_URL;
+  if (!base) return undefined;
+  const isDirect =
+    base.includes("/main/evm/") ||
+    /alchemy|infura|quicknode|ankr|publicnode|cloudflare-eth|llamarpc/i.test(base);
+  return isDirect ? base : `${base}/main/evm/${MAINNET_CHAIN_ID}`;
+}
+
+function mainnetClient() {
+  return createPublicClient({
+    chain: mainnet,
+    transport: http(mainnetRpcUrl()),
+  });
+}
+
+function looksLikeEnsName(input: string): boolean {
+  // Accept a.b[.c…] with at least one dot and no 0x prefix.
+  return /^[^\s]+\.[^\s]+$/.test(input) && !input.startsWith("0x");
+}
+
+export async function resolveRecipient(rawInput: string): Promise<ResolveResult> {
+  const input = rawInput.trim();
+  if (!input) return { error: "INVALID_INPUT" };
+
+  if (isAddress(input)) {
+    return { resolved: getAddress(input) };
+  }
+
+  if (!looksLikeEnsName(input)) {
+    return { error: "INVALID_INPUT" };
+  }
+
+  const normalized = (() => {
+    try {
+      return normalize(input);
+    } catch {
+      return null;
+    }
+  })();
+  if (!normalized) return { error: "INVALID_INPUT" };
+
+  const cached = cache.get(normalized);
+  if (cached) return cached;
+
+  try {
+    const client = mainnetClient();
+    const addr = await client.getEnsAddress({ name: normalized });
+    if (!addr) return { error: "ENS_RESOLUTION_FAILED" };
+    const result: ResolveSuccess = { resolved: getAddress(addr), label: input };
+    cache.set(normalized, result);
+    return result;
+  } catch (err) {
+    console.warn("[ENS] resolution error:", err);
+    return { error: "ENS_RESOLUTION_FAILED" };
+  }
+}
+
+export function clearResolutionCache() {
+  cache.clear();
+}

--- a/lib/redis/idempotency.ts
+++ b/lib/redis/idempotency.ts
@@ -1,0 +1,88 @@
+/**
+ * Idempotency-key wrapper for money-moving endpoints.
+ *
+ * Guarantees: a given `(userId, key)` pair executes the handler at most once
+ * within `ttlSec`. Subsequent requests within the window return the cached
+ * response (serialised as JSON).
+ *
+ * Production posture (see tasks/architecture-usdc-send.md §10): fail closed
+ * when Redis is unreachable — better to reject a send than to execute twice.
+ * The in-memory fallback is only safe in dev (single process, loses state on
+ * restart) and is disabled automatically in NODE_ENV=production by the
+ * underlying `getRedisClient()`.
+ *
+ * Key scheme: `transfer:idem:{userId}:{key}` — DID-scoped so collision across
+ * users is impossible.
+ */
+
+import { getCacheInterface } from "./client";
+
+const PREFIX = "transfer:idem";
+const DEFAULT_TTL_SEC = 60;
+
+export interface IdempotencyOptions {
+  ttlSec?: number;
+  /** Shorter second lock TTL guards against duplicate-burst races. */
+  lockTtlSec?: number;
+}
+
+export class IdempotencyBusyError extends Error {
+  readonly code = "IDEMPOTENCY_BUSY";
+  constructor(message = "A request with this idempotency key is already in flight") {
+    super(message);
+    this.name = "IdempotencyBusyError";
+  }
+}
+
+function buildKey(userId: string, key: string): string {
+  // Defensive: strip whitespace + non-printable chars; cap length.
+  const safeKey = key.trim().slice(0, 128);
+  return `${PREFIX}:${userId}:${safeKey}`;
+}
+
+/**
+ * Execute `fn` at most once per `(userId, key)` within the TTL window.
+ * - First caller runs `fn`, caches the result, and returns it.
+ * - Concurrent callers with the same key see a lock and throw
+ *   `IdempotencyBusyError` — the client should retry after a short backoff.
+ * - Callers arriving after completion (within TTL) get the cached result.
+ */
+export async function withIdempotencyKey<T>(
+  userId: string,
+  key: string,
+  fn: () => Promise<T>,
+  opts: IdempotencyOptions = {}
+): Promise<T> {
+  const ttlSec = opts.ttlSec ?? DEFAULT_TTL_SEC;
+  const lockTtlSec = opts.lockTtlSec ?? 30;
+  const cache = await getCacheInterface();
+  const fullKey = buildKey(userId, key);
+  const lockKey = `${fullKey}:lock`;
+
+  // Fast path: response cached from a prior run.
+  const cached = await cache.get(fullKey);
+  if (cached) {
+    try {
+      return JSON.parse(cached) as T;
+    } catch {
+      // Corrupt cache entry — fall through and re-execute.
+      await cache.del(fullKey);
+    }
+  }
+
+  // Acquire short-lived execution lock.
+  const acquired = await cache.setNX(lockKey, "1", lockTtlSec);
+  if (!acquired) {
+    throw new IdempotencyBusyError();
+  }
+
+  try {
+    const result = await fn();
+    // Cache the serialised result before releasing the lock so a racing caller
+    // reads the completed response, not an empty slot.
+    await cache.set(fullKey, JSON.stringify(result), ttlSec);
+    return result;
+  } finally {
+    await cache.del(lockKey);
+  }
+}

--- a/lib/zerodev/constants.ts
+++ b/lib/zerodev/constants.ts
@@ -2,8 +2,24 @@
  * Shared ZeroDev constants — single source of truth.
  */
 
+import { getAddress } from "viem";
+
 /** EntryPoint V0.7 object (required format for ZeroDev SDK v5) */
 export const ENTRYPOINT_V07 = {
   address: "0x0000000071727De22E5E9d8BAf0edAc6f37da032" as `0x${string}`,
   version: "0.7" as const,
 };
+
+export const ZERODEV_USDC_PAYMASTER_BASE = getAddress(
+  "0x7EE87982c03463DbAfe27A50b3D8e4FfAf1435F7"
+);
+
+export const PAYMASTER_ABI = [
+  {
+    inputs: [],
+    name: "treasury",
+    outputs: [{ name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;

--- a/lib/zerodev/kernel-client.ts
+++ b/lib/zerodev/kernel-client.ts
@@ -17,6 +17,21 @@ import { baseClient } from "@/lib/shared/rpc-client";
 import { ENTRYPOINT_V07 } from "@/lib/zerodev/constants";
 
 /**
+ * Optional paymaster object compatible with `createKernelAccountClient({ paymaster })`.
+ * Send path passes `createUsdcPaymaster()`. Agent path passes nothing (sponsored).
+ */
+export type KernelPaymaster = {
+  getPaymasterData: (userOperation: any) => Promise<any>;
+};
+
+export interface CreateDeserializedOptions {
+  /** When set, the kernel client uses ERC-20 paymaster mode (customer-paid). */
+  paymaster?: KernelPaymaster;
+  /** Skip the enable signature (permission already installed on-chain). */
+  preInstalled?: boolean;
+}
+
+/**
  * Create a ZeroDev Kernel client from a serialized permission account.
  *
  * This is the RECOMMENDED path for server-side execution. The serialized account
@@ -34,24 +49,27 @@ import { ENTRYPOINT_V07 } from "@/lib/zerodev/constants";
  */
 export async function createDeserializedKernelClient(
   serializedAccount: string,
-  options?: { preInstalled?: boolean }
+  options?: CreateDeserializedOptions
 ) {
   console.log("[KernelClient] Creating kernel client from serialized account...");
 
   const shouldPatch = options?.preInstalled ?? false;
+  const paymaster = options?.paymaster;
 
   // NOTE: EIP-7702 authorization nonce replay protection is handled by the protocol.
   // The authorization nonce is the EOA's transaction nonce at signing time.
   // Once the delegation tx is mined, that nonce is consumed and cannot be replayed.
   // The EntryPoint contract also manages UserOp nonces independently via 2D nonces.
 
-  const kernelClient = await _buildKernelClient(serializedAccount, shouldPatch);
+  const kernelClient = await _buildKernelClient(serializedAccount, shouldPatch, paymaster);
 
   // Wrap sendUserOperation with automatic retry for "duplicate permissionHash".
   // After re-registration with a new permissionHash, the first UserOp installs the validator
   // (enable signature included). On subsequent calls, the enable signature causes "duplicate
   // permissionHash" — we catch this and retry with preInstalled=true (skipping enable sig).
-  // This is transparent to all callers — no executor changes needed.
+  //
+  // IMPORTANT: the retry path MUST re-pass `paymaster` or the retried UserOp silently
+  // drops sponsorship. See tasks/architecture-usdc-send.md §6.2.
   if (!shouldPatch) {
     const originalSendUserOp = kernelClient.sendUserOperation.bind(kernelClient);
     kernelClient.sendUserOperation = async (args: any) => {
@@ -64,7 +82,7 @@ export async function createDeserializedKernelClient(
         if (!isDuplicate) throw error;
 
         console.log("[KernelClient] duplicate permissionHash — retrying with preInstalled=true");
-        const patchedClient = await _buildKernelClient(serializedAccount, true);
+        const patchedClient = await _buildKernelClient(serializedAccount, true, paymaster);
         return await patchedClient.sendUserOperation(args);
       }
     };
@@ -74,7 +92,11 @@ export async function createDeserializedKernelClient(
 }
 
 /** Internal: build a kernel client with or without enable signature */
-async function _buildKernelClient(serializedAccount: string, preInstalled: boolean) {
+async function _buildKernelClient(
+  serializedAccount: string,
+  preInstalled: boolean,
+  paymaster?: KernelPaymaster
+) {
   const publicClient = baseClient;
 
   const { createKernelAccountClient } = await import("@zerodev/sdk");
@@ -127,9 +149,12 @@ async function _buildKernelClient(serializedAccount: string, preInstalled: boole
     account: kernelAccount,
     chain: base,
     bundlerTransport: http(bundlerUrl),
+    ...(paymaster ? { paymaster } : {}),
   });
 
-  console.log("[KernelClient] Kernel client created from deserialized account");
+  console.log(
+    `[KernelClient] Kernel client created from deserialized account (paymaster=${paymaster ? "on" : "off"})`
+  );
   return kernelClient;
 }
 

--- a/lib/zerodev/paymaster-client.ts
+++ b/lib/zerodev/paymaster-client.ts
@@ -1,0 +1,119 @@
+/**
+ * ZeroDev ERC-20 paymaster integration for customer-paid USDC sends.
+ *
+ * See tasks/architecture-usdc-send.md §6 for the threading model.
+ * The paymaster contract (on Base): see `ZERODEV_USDC_PAYMASTER_BASE`.
+ */
+
+import { decodeEventLog, erc20Abi, type Hex } from "viem";
+import { base } from "viem/chains";
+import { baseClient } from "@/lib/shared/rpc-client";
+import { USDC_ADDRESS } from "@/lib/config";
+import { PAYMASTER_ABI, ZERODEV_USDC_PAYMASTER_BASE } from "./constants";
+
+type UsdcPaymasterClient = Awaited<ReturnType<typeof createUsdcPaymaster>>;
+
+/**
+ * Build the ZeroDev paymaster client used for ERC-20-mode sponsorship.
+ * Pass the return value as `paymaster` to `createKernelAccountClient`.
+ * A missing `ZERODEV_PAYMASTER_RPC` (or explicit `ZERODEV_PROJECT_ID`) throws —
+ * the send path has no fallback; it must have a paymaster or it's broken.
+ */
+export async function createUsdcPaymaster() {
+  // Accept any of: the new ZERODEV_PAYMASTER_RPC, the existing PAYMASTER_URL
+  // (already configured on some envs), or derive from ZERODEV_PROJECT_ID.
+  const paymasterUrl =
+    process.env.ZERODEV_PAYMASTER_RPC ||
+    process.env.PAYMASTER_URL ||
+    (process.env.ZERODEV_PROJECT_ID
+      ? `https://rpc.zerodev.app/api/v3/${process.env.ZERODEV_PROJECT_ID}/chain/8453`
+      : undefined);
+
+  if (!paymasterUrl) {
+    throw new Error(
+      "[UsdcPaymaster] ZERODEV_PAYMASTER_RPC or ZERODEV_PROJECT_ID required for customer-paid sends"
+    );
+  }
+
+  const { createZeroDevPaymasterClient } = await import("@zerodev/sdk");
+  const { http } = await import("viem");
+
+  const paymaster = createZeroDevPaymasterClient({
+    chain: base,
+    transport: http(paymasterUrl),
+  });
+
+  return {
+    // viem's kernel client calls getPaymasterData during prepareUserOperation.
+    // We delegate to sponsorUserOperation with gasToken=USDC for ERC-20 mode.
+    getPaymasterData: (userOperation: any) =>
+      paymaster.sponsorUserOperation({
+        userOperation,
+        gasToken: USDC_ADDRESS,
+      }),
+    // Stub matches viem's PaymasterActions shape; we don't need a special stub
+    // because sponsorUserOperation handles both the stub and final data.
+    getPaymasterStubData: (userOperation: any) =>
+      paymaster.sponsorUserOperation({
+        userOperation,
+        gasToken: USDC_ADDRESS,
+      }),
+  };
+}
+
+export type { UsdcPaymasterClient };
+
+/**
+ * Read the paymaster's treasury address (where USDC fees are pulled).
+ * Cached in-module since the value never changes in practice.
+ */
+let _treasuryCache: `0x${string}` | null = null;
+
+export async function getPaymasterTreasury(): Promise<`0x${string}`> {
+  if (_treasuryCache) return _treasuryCache;
+  const addr = (await baseClient.readContract({
+    address: ZERODEV_USDC_PAYMASTER_BASE,
+    abi: PAYMASTER_ABI,
+    functionName: "treasury",
+  })) as `0x${string}`;
+  _treasuryCache = addr;
+  return addr;
+}
+
+export interface PaymasterFeeParseArgs {
+  /** Logs from `receipt.logs` returned by `waitForUserOperationReceipt`. */
+  logs: ReadonlyArray<{ address: `0x${string}`; topics: readonly Hex[]; data: Hex }>;
+  smartAccount: `0x${string}`;
+  paymasterTreasury: `0x${string}`;
+}
+
+/**
+ * Parse the actual USDC fee charged by the paymaster from the UserOp receipt.
+ * Finds the ERC-20 `Transfer(smartAccount → paymasterTreasury)` log.
+ * Returns `0n` if not found (caller should log and surface as "fee unknown").
+ */
+export function parsePaymasterFeeFromReceipt(args: PaymasterFeeParseArgs): bigint {
+  const smartAccountLower = args.smartAccount.toLowerCase();
+  const treasuryLower = args.paymasterTreasury.toLowerCase();
+  const usdcLower = USDC_ADDRESS.toLowerCase();
+
+  for (const log of args.logs) {
+    if (log.address.toLowerCase() !== usdcLower) continue;
+    try {
+      const decoded = decodeEventLog({
+        abi: erc20Abi,
+        data: log.data,
+        topics: log.topics as [Hex, ...Hex[]],
+      });
+      if (decoded.eventName !== "Transfer") continue;
+      const { from, to, value } = decoded.args as { from: Hex; to: Hex; value: bigint };
+      if (from.toLowerCase() === smartAccountLower && to.toLowerCase() === treasuryLower) {
+        return value;
+      }
+    } catch {
+      // Not a Transfer log; skip.
+    }
+  }
+
+  return 0n;
+}

--- a/lib/zerodev/transfer-executor.ts
+++ b/lib/zerodev/transfer-executor.ts
@@ -1,109 +1,161 @@
 /**
- * Gasless Transfer Executor with ZeroDev
- * Executes USDC transfers using transfer-only session keys
+ * Transfer Executor with ZeroDev.
+ *
+ * Customer-paid mode: user approves the ZeroDev ERC-20 paymaster for a capped
+ * amount of USDC and the paymaster pulls the fee post-execution. No Tapioca
+ * subsidy. See tasks/architecture-usdc-send.md §7 (executor state diagram).
+ *
+ * Legacy sponsored path (`executeGaslessTransfer`) is kept as a no-op shim that
+ * throws — the UI no longer calls it but tests may reference the symbol.
  */
 
-import { encodeFunctionData, erc20Abi, parseUnits } from "viem";
-import { createDeserializedKernelClient, createSessionKernelClient } from "./kernel-client";
+import { encodeFunctionData, erc20Abi, formatUnits, parseUnits } from "viem";
+import { createDeserializedKernelClient } from "./kernel-client";
 import { withBuilderCode } from "@/lib/builder-code";
 import { validateTransferRecipient } from "./transfer-recipient-validator";
-import { USDC_ADDRESS } from "@/lib/config";
+import { FEE_CAP_USDC, USDC_ADDRESS, USDC_PAYMASTER_ADDRESS } from "@/lib/config";
+import { baseClient } from "@/lib/shared/rpc-client";
+import {
+  createUsdcPaymaster,
+  getPaymasterTreasury,
+  parsePaymasterFeeFromReceipt,
+} from "./paymaster-client";
 
-export interface GaslessTransferParams {
+export interface UserPaidTransferParams {
   userAddress: `0x${string}`;
   smartAccountAddress: `0x${string}`;
   recipient: `0x${string}`;
   amount: string; // Amount in USDC (e.g., "10.50")
-  serializedAccount?: string; // Serialized kernel account (new pattern)
-  // Legacy fields
-  sessionPrivateKey?: `0x${string}`;
-  eip7702SignedAuth?: any;
+  serializedAccount: string; // Serialized kernel account (v2 session)
 }
 
-export interface GaslessTransferResult {
+export interface UserPaidTransferResult {
   hash: string;
   success: boolean;
   error?: string;
   userOpHash?: string;
+  /** Actual USDC fee charged by the paymaster (decimal string, 6 dp). */
+  feePaid?: string;
 }
 
+// Legacy alias kept for external callers/tests — prefer the new names.
+export type GaslessTransferParams = UserPaidTransferParams & {
+  sessionPrivateKey?: `0x${string}`;
+  eip7702SignedAuth?: any;
+};
+export type GaslessTransferResult = UserPaidTransferResult;
+
 /**
- * Execute gasless USDC transfer via ZeroDev bundler
+ * Execute a customer-paid USDC transfer via the ZeroDev ERC-20 paymaster.
+ *
+ * Flow:
+ *   1. Pre-read `USDC.allowance(smartAccount, paymaster)` (cheap RPC read).
+ *   2. If allowance < FEE_CAP_USDC, prepend a `USDC.approve(paymaster, FEE_CAP_USDC)` call.
+ *   3. Always append `USDC.transfer(recipient, amount)`.
+ *   4. Submit as ONE batched UserOp with the paymaster-enabled kernel client.
+ *   5. Parse `ERC20.Transfer(smartAccount → paymasterTreasury)` from the
+ *      receipt logs to surface the actual fee.
  */
-export async function executeGaslessTransfer(
-  params: GaslessTransferParams
-): Promise<GaslessTransferResult> {
+export async function executeUserPaidTransfer(
+  params: UserPaidTransferParams
+): Promise<UserPaidTransferResult> {
   try {
-    console.log("[GaslessTransfer] Starting transfer execution...");
-    console.log("[GaslessTransfer] From:", params.smartAccountAddress);
-    console.log("[GaslessTransfer] To:", params.recipient);
-    console.log("[GaslessTransfer] Amount:", params.amount, "USDC");
+    console.log("[UserPaidTransfer] Starting transfer execution...");
+    console.log("[UserPaidTransfer] From:", params.smartAccountAddress);
+    console.log("[UserPaidTransfer] To:", params.recipient);
+    console.log("[UserPaidTransfer] Amount:", params.amount, "USDC");
 
-    // Check if simulation mode
-    const isSimulation = process.env.AGENT_SIMULATION_MODE === "true";
-
-    if (isSimulation) {
-      console.log("[GaslessTransfer] SIMULATION MODE - No real transaction");
+    if (process.env.AGENT_SIMULATION_MODE === "true") {
+      console.log("[UserPaidTransfer] SIMULATION MODE - No real transaction");
       const mockHash = `0x${Math.random().toString(16).slice(2)}${Math.random().toString(16).slice(2)}${Math.random().toString(16).slice(2)}`;
       return {
         hash: mockHash,
         success: true,
         userOpHash: `0xUserOp${Math.random().toString(16).slice(2)}`,
+        feePaid: "0.000000",
       };
     }
 
-    // Create kernel client — prefer deserialized account (new pattern)
-    let kernelClient;
-    if (params.serializedAccount) {
-      console.log("[GaslessTransfer] Using deserialized kernel client");
-      kernelClient = await createDeserializedKernelClient(params.serializedAccount);
-    } else if (params.sessionPrivateKey) {
-      console.warn("[GaslessTransfer] Using legacy session key path — user should re-register");
-      const transferSelector = encodeFunctionData({
-        abi: erc20Abi,
-        functionName: "transfer",
-        args: ["0x0000000000000000000000000000000000000000", BigInt(0)],
-      }).slice(0, 10) as `0x${string}`;
-      kernelClient = await createSessionKernelClient({
-        smartAccountAddress: params.smartAccountAddress,
-        sessionPrivateKey: params.sessionPrivateKey,
-        eip7702SignedAuth: params.eip7702SignedAuth,
-        permissions: [{ target: USDC_ADDRESS, selector: transferSelector }],
-      });
-    } else {
-      throw new Error("No serializedAccount or sessionPrivateKey provided. User must register.");
+    if (!params.serializedAccount) {
+      throw new Error("SESSION_UPGRADE_REQUIRED");
     }
 
-    // Build USDC transfer call
-    const amountInUSDC = parseUnits(params.amount, 6);
-
-    const transferCallData = encodeFunctionData({
+    // Step 1: pre-read allowance (OQ-6 optimization — skip approve when already sufficient).
+    const currentAllowance = (await baseClient.readContract({
+      address: USDC_ADDRESS,
       abi: erc20Abi,
-      functionName: "transfer",
-      args: [params.recipient, amountInUSDC],
+      functionName: "allowance",
+      args: [params.smartAccountAddress, USDC_PAYMASTER_ADDRESS],
+    })) as bigint;
+
+    const needsApprove = currentAllowance < FEE_CAP_USDC;
+    console.log(
+      `[UserPaidTransfer] allowance=${currentAllowance} cap=${FEE_CAP_USDC} needsApprove=${needsApprove}`
+    );
+
+    // Step 2+3: build batched calls.
+    const amountInUsdc = parseUnits(params.amount, 6);
+    const calls: Array<{ to: `0x${string}`; value: bigint; data: `0x${string}` }> = [];
+
+    if (needsApprove) {
+      calls.push({
+        to: USDC_ADDRESS,
+        value: 0n,
+        data: encodeFunctionData({
+          abi: erc20Abi,
+          functionName: "approve",
+          args: [USDC_PAYMASTER_ADDRESS, FEE_CAP_USDC],
+        }),
+      });
+    }
+
+    calls.push({
+      to: USDC_ADDRESS,
+      value: 0n,
+      data: encodeFunctionData({
+        abi: erc20Abi,
+        functionName: "transfer",
+        args: [params.recipient, amountInUsdc],
+      }),
     });
 
-    console.log("[GaslessTransfer] Building transfer call...");
+    // Step 4: submit batched UserOp through the paymaster-enabled kernel client.
+    const paymaster = await createUsdcPaymaster();
+    const kernelClient = await createDeserializedKernelClient(params.serializedAccount, {
+      paymaster,
+    });
 
     const userOpHash = await kernelClient.sendUserOperation({
-      calls: withBuilderCode([{ to: USDC_ADDRESS, value: BigInt(0), data: transferCallData }]),
+      calls: withBuilderCode(calls),
     });
 
-    console.log("[GaslessTransfer] UserOp submitted:", userOpHash);
+    console.log("[UserPaidTransfer] UserOp submitted:", userOpHash);
 
-    const receipt = await kernelClient.waitForUserOperationReceipt({
-      hash: userOpHash,
-    });
+    const receipt = await kernelClient.waitForUserOperationReceipt({ hash: userOpHash });
+    console.log("[UserPaidTransfer] Transaction confirmed:", receipt.receipt.transactionHash);
 
-    console.log("[GaslessTransfer] Transaction confirmed:", receipt.receipt.transactionHash);
+    // Step 5: parse actual fee from the paymaster-treasury Transfer log.
+    let feePaid = "0";
+    try {
+      const treasury = await getPaymasterTreasury();
+      const rawFee = parsePaymasterFeeFromReceipt({
+        logs: receipt.receipt.logs as any,
+        smartAccount: params.smartAccountAddress,
+        paymasterTreasury: treasury,
+      });
+      feePaid = formatUnits(rawFee, 6);
+    } catch (err) {
+      console.warn("[UserPaidTransfer] Fee parse failed (non-fatal):", err);
+    }
 
     return {
       hash: receipt.receipt.transactionHash,
       success: true,
       userOpHash,
+      feePaid,
     };
   } catch (error: any) {
-    console.error("[GaslessTransfer] Execution error:", error);
+    console.error("[UserPaidTransfer] Execution error:", error);
     return {
       hash: "",
       success: false,
@@ -111,6 +163,12 @@ export async function executeGaslessTransfer(
     };
   }
 }
+
+/**
+ * @deprecated Use `executeUserPaidTransfer`. This alias is kept so existing
+ * callers (tests, etc.) don't break in the same PR — they should migrate.
+ */
+export const executeGaslessTransfer = executeUserPaidTransfer;
 
 /**
  * Validate transfer parameters before execution

--- a/lib/zerodev/transfer-session.ts
+++ b/lib/zerodev/transfer-session.ts
@@ -11,11 +11,14 @@ import type { Hex } from "viem";
 import { base } from "viem/chains";
 import { createWalletClient, custom, encodeFunctionData, erc20Abi, parseAbi } from "viem";
 import { privateKeyToAccount, generatePrivateKey, toAccount } from "viem/accounts";
-import { USDC_ADDRESS } from "@/lib/config";
+import { FEE_CAP_USDC, USDC_ADDRESS, USDC_PAYMASTER_ADDRESS } from "@/lib/config";
 import { baseClient } from "@/lib/shared/rpc-client";
 
 // Maximum USDC amount per transfer session call (500 USDC with 6 decimals)
 const MAX_USDC_PER_TRANSFER = BigInt(500) * BigInt(1e6);
+
+/** CallPolicy version stamped into every new transfer session. */
+export const TRANSFER_PERMISSIONS_VERSION = 2;
 
 import { ENTRYPOINT_V07 } from "@/lib/zerodev/constants";
 
@@ -31,6 +34,12 @@ export interface TransferSessionAuthorization {
   serializedAccount?: string; // Serialized kernel account (encrypted at rest). Optional for backward compat.
   expiry: number;
   createdAt: number;
+  /**
+   * CallPolicy schema version. Missing field = v1 (legacy transfer-only).
+   * v2 = transfer + paymaster approve (customer-paid sends).
+   * Server gates on `permissionsVersion >= 2` for /transfer/send.
+   */
+  permissionsVersion?: number;
   // Legacy field — kept for backward compatibility with old sessions.
   // New sessions do NOT populate this field.
   sessionPrivateKey?: `0x${string}`;
@@ -102,7 +111,9 @@ export async function createTransferSessionKey(
     // Convert session key account to a ModularSigner
     const sessionSigner = await toECDSASigner({ signer: sessionKeyAccount });
 
-    // Create call policy restricted to USDC.transfer() with amount cap
+    // CallPolicy v2 — transfer + paymaster approve (customer-paid sends).
+    // Per CLAUDE.md Session Key Checklist, the paymaster target must be added
+    // to the permissions array; otherwise UserOps hit AA23 at gas estimation.
     const callPolicy = toCallPolicy({
       policyVersion: CallPolicyVersion.V0_0_5,
       permissions: [
@@ -113,6 +124,18 @@ export async function createTransferSessionKey(
           args: [
             null, // any recipient
             { condition: ParamCondition.LESS_THAN_OR_EQUAL, value: MAX_USDC_PER_TRANSFER },
+          ],
+          valueLimit: 0n,
+        },
+        {
+          // Spender pinned via ParamCondition.EQUAL so a leaked session key
+          // cannot approve arbitrary contracts.
+          target: USDC_ADDRESS,
+          abi: parseAbi(["function approve(address spender, uint256 amount) returns (bool)"]),
+          functionName: "approve",
+          args: [
+            { condition: ParamCondition.EQUAL, value: USDC_PAYMASTER_ADDRESS },
+            { condition: ParamCondition.LESS_THAN_OR_EQUAL, value: FEE_CAP_USDC },
           ],
           valueLimit: 0n,
         },
@@ -191,6 +214,7 @@ export async function createTransferSessionKey(
       serializedAccount,
       expiry,
       createdAt: Date.now(),
+      permissionsVersion: TRANSFER_PERMISSIONS_VERSION,
     };
   } catch (error: any) {
     console.error("[TransferSession] Session creation failed:", error);

--- a/tests/integration/api/transfer/send/route.test.ts
+++ b/tests/integration/api/transfer/send/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
 // 1. Define mock implementation first
@@ -25,6 +25,7 @@ vi.mock("@/lib/security/session-encryption", () => ({
 
 vi.mock("@/lib/zerodev/transfer-session", () => ({
   validateTransferSession: vi.fn(),
+  TRANSFER_PERMISSIONS_VERSION: 2,
 }));
 
 vi.mock("@/lib/redis/rate-limiter", () => ({
@@ -33,14 +34,29 @@ vi.mock("@/lib/redis/rate-limiter", () => ({
   checkAndRecordRateLimit: vi.fn(),
 }));
 
+vi.mock("@/lib/redis/idempotency", () => ({
+  withIdempotencyKey: vi.fn((_userId: string, _key: string, fn: () => Promise<any>) => fn()),
+  IdempotencyBusyError: class extends Error {
+    code = "IDEMPOTENCY_BUSY";
+  },
+}));
+
 vi.mock("@/lib/zerodev/transfer-executor", () => ({
   validateTransferParams: vi.fn(),
-  executeGaslessTransfer: vi.fn(),
+  executeUserPaidTransfer: vi.fn(),
 }));
 
 vi.mock("@/lib/zerodev/transfer-recipient-validator", () => ({
   validateTransferRecipient: vi.fn(),
 }));
+
+vi.mock("@/lib/config", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/config")>("@/lib/config");
+  return {
+    ...actual,
+    isUsdcPaymasterEnabledServer: () => true,
+  };
+});
 
 // 3. Import module under test
 import { POST } from "@/app/api/transfer/send/route";
@@ -48,7 +64,7 @@ import { requireAuthForAddress } from "@/lib/auth/middleware";
 import { decryptAuthorization } from "@/lib/security/session-encryption";
 import { validateTransferSession } from "@/lib/zerodev/transfer-session";
 import { checkTransferRateLimitRedis, checkAndRecordRateLimit } from "@/lib/redis/rate-limiter";
-import { validateTransferParams, executeGaslessTransfer } from "@/lib/zerodev/transfer-executor";
+import { validateTransferParams, executeUserPaidTransfer } from "@/lib/zerodev/transfer-executor";
 import { validateTransferRecipient } from "@/lib/zerodev/transfer-recipient-validator";
 
 describe("Transfer Send API", () => {
@@ -59,7 +75,7 @@ describe("Transfer Send API", () => {
     vi.clearAllMocks();
 
     // Default happy path mocks
-    (requireAuthForAddress as any).mockResolvedValue({ authenticated: true });
+    (requireAuthForAddress as any).mockResolvedValue({ authenticated: true, userId: "privy:1" });
 
     mockSql.mockResolvedValue([
       {
@@ -71,8 +87,7 @@ describe("Transfer Send API", () => {
     (decryptAuthorization as any).mockReturnValue({
       smartAccountAddress: "0xsmart",
       serializedAccount: "base64SerializedAccount",
-      // Legacy field also present for backward compat
-      sessionPrivateKey: "0xpriv",
+      permissionsVersion: 2,
     });
 
     (validateTransferSession as any).mockReturnValue({ valid: true });
@@ -85,10 +100,11 @@ describe("Transfer Send API", () => {
 
     (validateTransferParams as any).mockReturnValue({ valid: true });
 
-    (executeGaslessTransfer as any).mockResolvedValue({
+    (executeUserPaidTransfer as any).mockResolvedValue({
       success: true,
       hash: "0xtxhash",
       userOpHash: "0xopHash",
+      feePaid: "0.03",
     });
   });
 
@@ -138,31 +154,59 @@ describe("Transfer Send API", () => {
     expect(res.status).toBe(404);
   });
 
-  it("should return 403 if gasless not enabled", async () => {
+  it("should return 409 SESSION_UPGRADE_REQUIRED when transfer_authorization is null (new user)", async () => {
     mockSql.mockResolvedValue([{ id: "user1", transfer_authorization: null }]);
 
     const req = createRequest({ address: mockUserAddress, recipient: mockRecipient, amount: "10" });
     const res = await POST(req);
+    const body = await res.json();
 
-    expect(res.status).toBe(403);
-    expect(await res.json()).toEqual(
-      expect.objectContaining({ error: expect.stringContaining("not enabled") })
-    );
+    expect(res.status).toBe(409);
+    expect(body.code).toBe("SESSION_UPGRADE_REQUIRED");
   });
 
-  it("should return 403 if session invalid", async () => {
-    (validateTransferSession as any).mockReturnValue({ valid: false, reason: "Expired" });
+  it("should return 409 SESSION_UPGRADE_REQUIRED for v1 legacy sessions", async () => {
+    (decryptAuthorization as any).mockReturnValue({
+      smartAccountAddress: "0xsmart",
+      serializedAccount: "legacySerialized",
+      permissionsVersion: 1, // legacy
+    });
 
     const req = createRequest({ address: mockUserAddress, recipient: mockRecipient, amount: "10" });
     const res = await POST(req);
+    const body = await res.json();
 
-    expect(res.status).toBe(403);
-    expect(await res.json()).toEqual(
-      expect.objectContaining({ error: "Transfer session invalid or expired" })
-    );
+    expect(res.status).toBe(409);
+    expect(body.code).toBe("SESSION_UPGRADE_REQUIRED");
   });
 
-  it("should return 429 if rate limit exceeded", async () => {
+  it("should return 409 SESSION_UPGRADE_REQUIRED when permissionsVersion is missing (treated as v1)", async () => {
+    (decryptAuthorization as any).mockReturnValue({
+      smartAccountAddress: "0xsmart",
+      serializedAccount: "legacySerialized",
+      // no permissionsVersion field — must default to v1
+    });
+
+    const req = createRequest({ address: mockUserAddress, recipient: mockRecipient, amount: "10" });
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(body.code).toBe("SESSION_UPGRADE_REQUIRED");
+  });
+
+  it("should return 401 SESSION_EXPIRED when session validation fails", async () => {
+    (validateTransferSession as any).mockReturnValue({ valid: false, reason: "Session expired" });
+
+    const req = createRequest({ address: mockUserAddress, recipient: mockRecipient, amount: "10" });
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.code).toBe("SESSION_EXPIRED");
+  });
+
+  it("should return 429 RATE_LIMIT_EXCEEDED when daily rate limit hit", async () => {
     (checkTransferRateLimitRedis as any).mockResolvedValue({
       allowed: false,
       remaining: 0,
@@ -171,20 +215,24 @@ describe("Transfer Send API", () => {
 
     const req = createRequest({ address: mockUserAddress, recipient: mockRecipient, amount: "10" });
     const res = await POST(req);
+    const body = await res.json();
 
     expect(res.status).toBe(429);
+    expect(body.code).toBe("RATE_LIMIT_EXCEEDED");
   });
 
-  it("should return 400 if params invalid", async () => {
+  it("should return 400 INVALID_PARAMS when param validation fails", async () => {
     (validateTransferParams as any).mockReturnValue({ valid: false, error: "Invalid amount" });
 
     const req = createRequest({ address: mockUserAddress, recipient: mockRecipient, amount: "10" });
     const res = await POST(req);
+    const body = await res.json();
 
     expect(res.status).toBe(400);
+    expect(body.code).toBe("INVALID_PARAMS");
   });
 
-  it("should execute transfer and return success", async () => {
+  it("should execute transfer and return success with feePaid", async () => {
     const req = createRequest({ address: mockUserAddress, recipient: mockRecipient, amount: "10" });
     const res = await POST(req);
     const body = await res.json();
@@ -192,19 +240,12 @@ describe("Transfer Send API", () => {
     expect(res.status).toBe(200);
     expect(body.success).toBe(true);
     expect(body.hash).toBe("0xtxhash");
-    expect(executeGaslessTransfer).toHaveBeenCalled();
-    // Verify DB insert for success
-    // The first call is SELECT, second is INSERT
-    expect(mockSql).toHaveBeenCalledTimes(2);
-    const insertCall = mockSql.mock.calls[1];
-    expect(insertCall[0][0]).toContain("INSERT INTO agent_actions");
-    expect(insertCall[1]).toBe("user1"); // user_id
-    expect(insertCall[2]).toBe("10"); // amount
-    expect(insertCall[3]).toBe("0xtxhash"); // tx_hash
+    expect(body.feePaid).toBe("0.03");
+    expect(executeUserPaidTransfer).toHaveBeenCalled();
   });
 
-  it("should handle execution failure", async () => {
-    (executeGaslessTransfer as any).mockResolvedValue({
+  it("should propagate bundler error message on execution failure", async () => {
+    (executeUserPaidTransfer as any).mockResolvedValue({
       success: false,
       error: "Bundler error",
     });
@@ -213,8 +254,24 @@ describe("Transfer Send API", () => {
     const res = await POST(req);
     const body = await res.json();
 
+    // Generic failure → 500 with TRANSFER_FAILED code; AA31 would be 503 PAYMASTER_UNAVAILABLE.
     expect(res.status).toBe(500);
     expect(body.success).toBe(false);
     expect(body.error).toBe("Bundler error");
+    expect(body.code).toBe("TRANSFER_FAILED");
+  });
+
+  it("should map AA31 bundler errors to 503 PAYMASTER_UNAVAILABLE", async () => {
+    (executeUserPaidTransfer as any).mockResolvedValue({
+      success: false,
+      error: "UserOp failed: AA31 paymaster deposit too low",
+    });
+
+    const req = createRequest({ address: mockUserAddress, recipient: mockRecipient, amount: "10" });
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(body.code).toBe("PAYMASTER_UNAVAILABLE");
   });
 });

--- a/tests/unit/hooks/useWallet.test.ts
+++ b/tests/unit/hooks/useWallet.test.ts
@@ -118,14 +118,15 @@ describe("useWallet", () => {
   });
 
   it("should send sponsored tokens via API", async () => {
-    // Mock status check
+    // Session already on v2 → no inline setup needed.
     (global.fetch as any)
       .mockResolvedValueOnce({
-        json: async () => ({ isEnabled: true }),
+        ok: true,
+        json: async () => ({ isEnabled: true, permissionsVersion: 2 }),
       })
-      // Mock transfer execution
       .mockResolvedValueOnce({
-        json: async () => ({ success: true, hash: "0xtxhash" }),
+        ok: true,
+        json: async () => ({ success: true, hash: "0xtxhash", feePaid: "0.03" }),
       });
 
     const { result } = renderHook(() => useWallet());

--- a/tests/unit/hooks/useWallet.test.ts
+++ b/tests/unit/hooks/useWallet.test.ts
@@ -159,4 +159,230 @@ describe("useWallet", () => {
       );
     }
   });
+
+  describe("sendUsdc phase emission", () => {
+    const validAddress = "0x1234567890123456789012345678901234567890";
+
+    it("emits submitting → confirming → success when session is v2", async () => {
+      (global.fetch as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ isEnabled: true, permissionsVersion: 2 }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            success: true,
+            hash: "0xtx",
+            userOpHash: "0xuo",
+            feePaid: "0.02",
+          }),
+        });
+
+      const { result } = renderHook(() => useWallet());
+      const phases: string[] = [];
+      const ctxs: any[] = [];
+      const out = await result.current.wallet!.sendUsdc(
+        { to: validAddress, amount: "10" },
+        (ctx) => {
+          phases.push(ctx.phase);
+          ctxs.push(ctx);
+        }
+      );
+
+      expect(phases).toEqual(["submitting", "submitting", "confirming", "success"]);
+      expect(ctxs[2]).toMatchObject({ phase: "confirming", userOpHash: "0xuo" });
+      expect(ctxs[3]).toMatchObject({
+        phase: "success",
+        txHash: "0xtx",
+        feePaid: "0.02",
+      });
+      expect(out).toEqual({ hash: "0xtx", userOpHash: "0xuo", feePaid: "0.02" });
+    });
+
+    it("runs inline session setup for a brand-new user (isEnabled=false)", async () => {
+      (global.fetch as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ isEnabled: false }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true, smartAccountAddress: "0xsmart" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true, hash: "0xtx", feePaid: "0.02" }),
+        });
+
+      const { result } = renderHook(() => useWallet());
+      const phases: string[] = [];
+
+      await result.current.wallet!.sendUsdc({ to: validAddress, amount: "5" }, (ctx) =>
+        phases.push(ctx.phase)
+      );
+
+      // FR-25: signing_session + registering fire on the inline setup path
+      expect(phases).toContain("signing_session");
+      expect(phases).toContain("registering");
+      expect(phases).toContain("success");
+
+      // Register endpoint was called with Bearer token
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        2,
+        "/api/transfer/register",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            Authorization: "Bearer mock-token",
+          }),
+        })
+      );
+    });
+
+    it("runs inline upgrade when stored permissionsVersion < 2", async () => {
+      (global.fetch as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ isEnabled: true, permissionsVersion: 1 }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true, hash: "0xtx" }),
+        });
+
+      const { result } = renderHook(() => useWallet());
+      const phases: string[] = [];
+      await result.current.wallet!.sendUsdc({ to: validAddress, amount: "5" }, (ctx) =>
+        phases.push(ctx.phase)
+      );
+
+      expect(phases).toContain("signing_session");
+    });
+
+    it("treats missing permissionsVersion as v1 and runs setup", async () => {
+      (global.fetch as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ isEnabled: true }), // no version field
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true, hash: "0xtx" }),
+        });
+
+      const { result } = renderHook(() => useWallet());
+      const phases: string[] = [];
+      await result.current.wallet!.sendUsdc({ to: validAddress, amount: "5" }, (ctx) =>
+        phases.push(ctx.phase)
+      );
+      expect(phases).toContain("signing_session");
+    });
+
+    it("sends Idempotency-Key header to /api/transfer/send", async () => {
+      (global.fetch as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ isEnabled: true, permissionsVersion: 2 }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true, hash: "0xtx" }),
+        });
+
+      const { result } = renderHook(() => useWallet());
+      await result.current.wallet!.sendUsdc({
+        to: validAddress,
+        amount: "5",
+        idempotencyKey: "fixed-key-xyz",
+      });
+
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        "/api/transfer/send",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "Idempotency-Key": "fixed-key-xyz",
+          }),
+        })
+      );
+    });
+
+    it("throws SendError with code from server on failure and emits error phase", async () => {
+      (global.fetch as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ isEnabled: true, permissionsVersion: 2 }),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          json: async () => ({
+            success: false,
+            error: "Gas too high",
+            code: "PAYMASTER_UNAVAILABLE",
+          }),
+        });
+
+      const { result } = renderHook(() => useWallet());
+      const phases: string[] = [];
+      await expect(
+        result.current.wallet!.sendUsdc(
+          { to: validAddress, amount: "5" },
+          (ctx) => phases.push(ctx.phase)
+        )
+      ).rejects.toMatchObject({ code: "PAYMASTER_UNAVAILABLE" });
+
+      expect(phases).toContain("error");
+    });
+
+    it("surfaces SESSION_SETUP_FAILED when registration fails", async () => {
+      (global.fetch as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ isEnabled: false }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: false, error: "bad signature" }),
+        });
+
+      const { result } = renderHook(() => useWallet());
+      await expect(
+        result.current.wallet!.sendUsdc({ to: validAddress, amount: "5" })
+      ).rejects.toMatchObject({ code: "SESSION_SETUP_FAILED" });
+    });
+
+    it("passes `label` through to /api/transfer/send body", async () => {
+      (global.fetch as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ isEnabled: true, permissionsVersion: 2 }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true, hash: "0xtx" }),
+        });
+
+      const { result } = renderHook(() => useWallet());
+      await result.current.wallet!.sendUsdc({
+        to: validAddress,
+        amount: "5",
+        label: "vitalik.eth",
+      });
+
+      const sendCall = (global.fetch as any).mock.calls.find(
+        ([url]: [string]) => url === "/api/transfer/send"
+      );
+      expect(sendCall).toBeDefined();
+      const body = JSON.parse(sendCall[1].body);
+      expect(body.label).toBe("vitalik.eth");
+    });
+  });
 });

--- a/tests/unit/lib/ens/cache.test.ts
+++ b/tests/unit/lib/ens/cache.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { LRU } from "@/lib/ens/cache";
+
+describe("LRU cache", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns undefined for missing keys", () => {
+    const c = new LRU<string>();
+    expect(c.get("nope")).toBeUndefined();
+  });
+
+  it("stores and retrieves a value", () => {
+    const c = new LRU<string>();
+    c.set("alice", "0xalice");
+    expect(c.get("alice")).toBe("0xalice");
+  });
+
+  it("evicts the oldest entry when max is exceeded", () => {
+    const c = new LRU<number>({ max: 2 });
+    c.set("a", 1);
+    c.set("b", 2);
+    c.set("c", 3); // evicts "a"
+    expect(c.get("a")).toBeUndefined();
+    expect(c.get("b")).toBe(2);
+    expect(c.get("c")).toBe(3);
+  });
+
+  it("refreshes recency on get so frequent reads stay in cache", () => {
+    const c = new LRU<number>({ max: 2 });
+    c.set("a", 1);
+    c.set("b", 2);
+    // Touch "a" so it becomes most-recently-used.
+    c.get("a");
+    c.set("c", 3); // should now evict "b", not "a"
+    expect(c.get("a")).toBe(1);
+    expect(c.get("b")).toBeUndefined();
+  });
+
+  it("expires entries after TTL", () => {
+    vi.useFakeTimers();
+    const c = new LRU<string>({ ttlMs: 1000 });
+    c.set("k", "v");
+    vi.advanceTimersByTime(999);
+    expect(c.get("k")).toBe("v");
+    vi.advanceTimersByTime(2);
+    expect(c.get("k")).toBeUndefined();
+  });
+});

--- a/tests/unit/lib/ens/resolver.test.ts
+++ b/tests/unit/lib/ens/resolver.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockGetEnsAddress } = vi.hoisted(() => ({
+  mockGetEnsAddress: vi.fn(),
+}));
+
+vi.mock("viem", async () => {
+  const actual = await vi.importActual<typeof import("viem")>("viem");
+  return {
+    ...actual,
+    createPublicClient: () => ({ getEnsAddress: mockGetEnsAddress }),
+  };
+});
+
+import { resolveRecipient, clearResolutionCache } from "@/lib/ens/resolver";
+
+describe("resolveRecipient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearResolutionCache();
+  });
+
+  it("returns a 0x address as-is without RPC", async () => {
+    const result = await resolveRecipient("0x1234567890123456789012345678901234567890");
+    expect(result).toEqual({
+      resolved: "0x1234567890123456789012345678901234567890",
+    });
+    expect(mockGetEnsAddress).not.toHaveBeenCalled();
+  });
+
+  it("checksums a lowercase 0x address on return", async () => {
+    // viem's isAddress(..., { strict: true }) rejects non-checksummed input.
+    // All-lowercase is accepted and we re-apply EIP-55 via getAddress.
+    const result = await resolveRecipient("0xabcdef0123456789012345678901234567890abc");
+    expect(result).toMatchObject({
+      resolved: expect.stringMatching(/^0x[a-fA-F0-9]{40}$/),
+    });
+  });
+
+  it("resolves a .eth name via ENS", async () => {
+    mockGetEnsAddress.mockResolvedValueOnce(
+      "0xabcdef0123456789012345678901234567890abc"
+    );
+    const result = await resolveRecipient("luis.eth");
+    expect(result).toMatchObject({
+      label: "luis.eth",
+      resolved: expect.stringMatching(/^0x/),
+    });
+    expect(mockGetEnsAddress).toHaveBeenCalledOnce();
+  });
+
+  it("resolves a .base.eth name via the same path", async () => {
+    mockGetEnsAddress.mockResolvedValueOnce(
+      "0x1111111111111111111111111111111111111111"
+    );
+    const result = await resolveRecipient("luis.base.eth");
+    expect(result).toMatchObject({
+      label: "luis.base.eth",
+      resolved: "0x1111111111111111111111111111111111111111",
+    });
+  });
+
+  it("returns ENS_RESOLUTION_FAILED when the name is not registered", async () => {
+    mockGetEnsAddress.mockResolvedValueOnce(null);
+    const result = await resolveRecipient("nonsense.eth");
+    expect(result).toEqual({ error: "ENS_RESOLUTION_FAILED" });
+  });
+
+  it("returns ENS_RESOLUTION_FAILED on RPC error", async () => {
+    mockGetEnsAddress.mockRejectedValueOnce(new Error("network down"));
+    const result = await resolveRecipient("luis.eth");
+    expect(result).toEqual({ error: "ENS_RESOLUTION_FAILED" });
+  });
+
+  it("rejects invalid input (no dot, not 0x)", async () => {
+    const result = await resolveRecipient("not-an-address");
+    expect(result).toEqual({ error: "INVALID_INPUT" });
+    expect(mockGetEnsAddress).not.toHaveBeenCalled();
+  });
+
+  it("caches repeated successful resolutions", async () => {
+    mockGetEnsAddress.mockResolvedValueOnce(
+      "0x2222222222222222222222222222222222222222"
+    );
+    await resolveRecipient("cached.eth");
+    await resolveRecipient("cached.eth");
+    expect(mockGetEnsAddress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/lib/redis/idempotency.test.ts
+++ b/tests/unit/lib/redis/idempotency.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockCache } = vi.hoisted(() => ({
+  mockCache: {
+    get: vi.fn(),
+    set: vi.fn(),
+    del: vi.fn(),
+    setNX: vi.fn(),
+    eval: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/redis/client", () => ({
+  getCacheInterface: vi.fn(() => Promise.resolve(mockCache)),
+}));
+
+import { IdempotencyBusyError, withIdempotencyKey } from "@/lib/redis/idempotency";
+
+describe("withIdempotencyKey", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCache.get.mockResolvedValue(null);
+    mockCache.setNX.mockResolvedValue(true);
+    mockCache.set.mockResolvedValue(undefined);
+    mockCache.del.mockResolvedValue(undefined);
+  });
+
+  it("runs the handler exactly once on first call", async () => {
+    const fn = vi.fn().mockResolvedValue({ status: 200, body: { success: true } });
+
+    const out = await withIdempotencyKey("user-1", "key-1", fn);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(out).toEqual({ status: 200, body: { success: true } });
+    expect(mockCache.setNX).toHaveBeenCalledWith(
+      expect.stringContaining("transfer:idem:user-1:key-1:lock"),
+      "1",
+      expect.any(Number)
+    );
+    expect(mockCache.set).toHaveBeenCalledWith(
+      "transfer:idem:user-1:key-1",
+      JSON.stringify({ status: 200, body: { success: true } }),
+      expect.any(Number)
+    );
+  });
+
+  it("returns cached response on second call without running handler", async () => {
+    mockCache.get.mockResolvedValueOnce(
+      JSON.stringify({ status: 200, body: { success: true, hash: "0xcached" } })
+    );
+    const fn = vi.fn();
+
+    const out = await withIdempotencyKey("user-1", "key-1", fn);
+
+    expect(fn).not.toHaveBeenCalled();
+    expect(out).toEqual({ status: 200, body: { success: true, hash: "0xcached" } });
+  });
+
+  it("throws IdempotencyBusyError when another worker holds the lock", async () => {
+    mockCache.setNX.mockResolvedValueOnce(false);
+    const fn = vi.fn();
+
+    await expect(withIdempotencyKey("user-1", "key-1", fn)).rejects.toBeInstanceOf(
+      IdempotencyBusyError
+    );
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("scopes keys per userId so collisions across users are impossible", async () => {
+    const fn = vi.fn().mockResolvedValue({ ok: true });
+
+    await withIdempotencyKey("alice", "shared-key", fn);
+    await withIdempotencyKey("bob", "shared-key", fn);
+
+    const setCalls = mockCache.set.mock.calls.map((c) => c[0]);
+    expect(setCalls).toContain("transfer:idem:alice:shared-key");
+    expect(setCalls).toContain("transfer:idem:bob:shared-key");
+  });
+
+  it("releases the lock on handler error so next call can retry", async () => {
+    const err = new Error("boom");
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(withIdempotencyKey("user-1", "key-1", fn)).rejects.toThrow("boom");
+    expect(mockCache.del).toHaveBeenCalledWith(
+      expect.stringContaining("transfer:idem:user-1:key-1:lock")
+    );
+  });
+
+  it("re-executes if cached JSON is corrupt", async () => {
+    mockCache.get.mockResolvedValueOnce("{not json");
+    const fn = vi.fn().mockResolvedValue({ ok: true });
+
+    const out = await withIdempotencyKey("user-1", "key-1", fn);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(out).toEqual({ ok: true });
+  });
+});

--- a/tests/unit/lib/zerodev/paymaster-fee-parse.test.ts
+++ b/tests/unit/lib/zerodev/paymaster-fee-parse.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { encodeEventTopics, encodeAbiParameters, getAddress, parseAbi } from "viem";
+import { parsePaymasterFeeFromReceipt } from "@/lib/zerodev/paymaster-client";
+import { USDC_ADDRESS } from "@/lib/config";
+
+const transferAbi = parseAbi([
+  "event Transfer(address indexed from, address indexed to, uint256 value)",
+]);
+
+function fakeUsdcTransferLog(from: `0x${string}`, to: `0x${string}`, value: bigint) {
+  const topics = encodeEventTopics({
+    abi: transferAbi,
+    eventName: "Transfer",
+    args: { from, to },
+  });
+  const data = encodeAbiParameters([{ type: "uint256" }], [value]);
+  return {
+    address: USDC_ADDRESS,
+    topics,
+    data,
+  };
+}
+
+const SMART_ACCOUNT = getAddress("0xaaaa000000000000000000000000000000000001");
+const TREASURY = getAddress("0xbbbb000000000000000000000000000000000002");
+const OTHER = getAddress("0xcccc000000000000000000000000000000000003");
+
+describe("parsePaymasterFeeFromReceipt", () => {
+  it("returns the value of a matching smartAccount → treasury transfer", () => {
+    const logs = [fakeUsdcTransferLog(SMART_ACCOUNT, TREASURY, 30_000n)];
+    const fee = parsePaymasterFeeFromReceipt({
+      logs,
+      smartAccount: SMART_ACCOUNT,
+      paymasterTreasury: TREASURY,
+    });
+    expect(fee).toBe(30_000n);
+  });
+
+  it("ignores transfers that are not to the treasury", () => {
+    const logs = [
+      fakeUsdcTransferLog(SMART_ACCOUNT, OTHER, 100_000n), // the user's own send
+    ];
+    const fee = parsePaymasterFeeFromReceipt({
+      logs,
+      smartAccount: SMART_ACCOUNT,
+      paymasterTreasury: TREASURY,
+    });
+    expect(fee).toBe(0n);
+  });
+
+  it("returns 0n when no matching log is found", () => {
+    const fee = parsePaymasterFeeFromReceipt({
+      logs: [],
+      smartAccount: SMART_ACCOUNT,
+      paymasterTreasury: TREASURY,
+    });
+    expect(fee).toBe(0n);
+  });
+
+  it("matches case-insensitively on addresses", () => {
+    const logs = [fakeUsdcTransferLog(SMART_ACCOUNT, TREASURY, 7_500n)];
+    // Inject different-case variants on both sides to verify normalisation.
+    const fee = parsePaymasterFeeFromReceipt({
+      logs,
+      smartAccount: SMART_ACCOUNT.toLowerCase() as `0x${string}`,
+      paymasterTreasury: TREASURY.toLowerCase() as `0x${string}`,
+    });
+    expect(fee).toBe(7_500n);
+  });
+
+  it("picks the paymaster log out of a multi-log receipt", () => {
+    const logs = [
+      fakeUsdcTransferLog(SMART_ACCOUNT, OTHER, 5_000_000n), // user send
+      fakeUsdcTransferLog(SMART_ACCOUNT, TREASURY, 20_000n), // fee
+    ];
+    const fee = parsePaymasterFeeFromReceipt({
+      logs,
+      smartAccount: SMART_ACCOUNT,
+      paymasterTreasury: TREASURY,
+    });
+    expect(fee).toBe(20_000n);
+  });
+});

--- a/tests/unit/lib/zerodev/session.test.ts
+++ b/tests/unit/lib/zerodev/session.test.ts
@@ -40,6 +40,8 @@ vi.mock("@/lib/redis/client", () => ({
 vi.mock("@/lib/config", () => ({
   CHAIN_CONFIG: { rpcUrl: "http://localhost:8545" },
   USDC_ADDRESS: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  USDC_PAYMASTER_ADDRESS: "0x7EE87982c03463DbAfe27A50b3D8e4FfAf1435F7",
+  FEE_CAP_USDC: 200_000n,
 }));
 
 vi.mock("viem", async (importOriginal) => {

--- a/tests/unit/lib/zerodev/session.test.ts
+++ b/tests/unit/lib/zerodev/session.test.ts
@@ -94,7 +94,10 @@ vi.mock("@zerodev/permissions/policies", () => ({
   toGasPolicy: vi.fn(),
   toRateLimitPolicy: vi.fn(),
   toTimestampPolicy: vi.fn(),
-  ParamCondition: { LESS_THAN_OR_EQUAL: "LESS_THAN_OR_EQUAL" },
+  ParamCondition: {
+    LESS_THAN_OR_EQUAL: "LESS_THAN_OR_EQUAL",
+    EQUAL: "EQUAL",
+  },
 }));
 
 vi.mock("@zerodev/permissions/signers", () => ({
@@ -204,6 +207,92 @@ describe("ZeroDev Session Management", () => {
         await expect(createTransferSessionKey(mockWallet, "0xUser")).rejects.toThrow(
           "Transfer session setup failed"
         );
+      });
+    });
+
+    // CT-2 regression guard: the CallPolicy v2 contract with the paymaster
+    // is the load-bearing security boundary. If a future refactor drops
+    // either permission OR un-pins the spender, a leaked session key could
+    // approve arbitrary contracts. These tests FAIL LOUDLY on regression.
+    describe("CallPolicy v2 shape (paymaster-approve + transfer)", () => {
+      const USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+      const PAYMASTER = "0x7EE87982c03463DbAfe27A50b3D8e4FfAf1435F7";
+
+      let permissions: any[];
+
+      beforeEach(async () => {
+        const mockWallet = {
+          getEthereumProvider: vi.fn().mockResolvedValue({}),
+          address: "0xUser",
+        };
+        mockGeneratePrivateKey.mockReturnValue("0xSessionPriv");
+        mockPrivateKeyToAccount.mockReturnValue({ address: "0xSessionKey" });
+        mockCreateKernelAccount.mockResolvedValue({ address: "0xSmartAccount" });
+        mockSerializePermissionAccount.mockResolvedValue("base64");
+
+        await createTransferSessionKey(mockWallet, "0xUser" as `0x${string}`);
+
+        // toCallPolicy is called with { policyVersion, permissions: [...] }
+        expect(mockToCallPolicy).toHaveBeenCalled();
+        const call = mockToCallPolicy.mock.calls[0][0];
+        permissions = call.permissions;
+      });
+
+      it("stamps permissionsVersion: 2 on the returned session", async () => {
+        const mockWallet = {
+          getEthereumProvider: vi.fn().mockResolvedValue({}),
+          address: "0xUser",
+        };
+        mockGeneratePrivateKey.mockReturnValue("0xSessionPriv");
+        mockPrivateKeyToAccount.mockReturnValue({ address: "0xSessionKey" });
+        mockCreateKernelAccount.mockResolvedValue({ address: "0xSmartAccount" });
+        mockSerializePermissionAccount.mockResolvedValue("base64");
+
+        const out = await createTransferSessionKey(mockWallet, "0xUser" as `0x${string}`);
+        expect(out.permissionsVersion).toBe(2);
+      });
+
+      it("contains exactly two permissions: transfer and approve", () => {
+        expect(permissions).toHaveLength(2);
+        const fns = permissions.map((p) => p.functionName);
+        expect(fns).toContain("transfer");
+        expect(fns).toContain("approve");
+      });
+
+      it("transfer permission targets USDC with a ≤ $500 cap", () => {
+        const transfer = permissions.find((p) => p.functionName === "transfer");
+        expect(transfer).toBeDefined();
+        expect(transfer.target.toLowerCase()).toBe(USDC.toLowerCase());
+        expect(transfer.valueLimit).toBe(0n);
+        const [recipientArg, amountArg] = transfer.args;
+        expect(recipientArg).toBeNull(); // any recipient allowed
+        expect(amountArg.condition).toBe("LESS_THAN_OR_EQUAL");
+        expect(amountArg.value).toBe(500n * 10n ** 6n);
+      });
+
+      it("approve permission pins spender to paymaster with ParamCondition.EQUAL", () => {
+        const approve = permissions.find((p) => p.functionName === "approve");
+        expect(approve).toBeDefined();
+        expect(approve.target.toLowerCase()).toBe(USDC.toLowerCase());
+        expect(approve.valueLimit).toBe(0n);
+
+        const [spenderArg, amountArg] = approve.args;
+        // LOAD-BEARING INVARIANT: spender pinned via EQUAL to the paymaster.
+        // If this drifts to LESS_THAN_OR_EQUAL or null, a leaked session key
+        // can approve any spender.
+        expect(spenderArg.condition).toBe("EQUAL");
+        expect(String(spenderArg.value).toLowerCase()).toBe(PAYMASTER.toLowerCase());
+
+        // Amount capped at FEE_CAP_USDC (0.20 USDC).
+        expect(amountArg.condition).toBe("LESS_THAN_OR_EQUAL");
+        expect(amountArg.value).toBe(200_000n);
+      });
+
+      it("does NOT contain any permission that lets the session key approve arbitrary contracts", () => {
+        const approve = permissions.find((p) => p.functionName === "approve");
+        // Sanity: any approve permission MUST have the spender pinned.
+        expect(approve.args[0].condition).not.toBe("LESS_THAN_OR_EQUAL");
+        expect(approve.args[0].value).toBeTruthy();
       });
     });
   });

--- a/tests/unit/lib/zerodev/transfer-executor.test.ts
+++ b/tests/unit/lib/zerodev/transfer-executor.test.ts
@@ -1,14 +1,30 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { executeGaslessTransfer, validateTransferParams } from "@/lib/zerodev/transfer-executor";
 import {
-  createDeserializedKernelClient,
-  createSessionKernelClient,
-} from "@/lib/zerodev/kernel-client";
+  executeUserPaidTransfer,
+  executeGaslessTransfer,
+  validateTransferParams,
+} from "@/lib/zerodev/transfer-executor";
+import { createDeserializedKernelClient } from "@/lib/zerodev/kernel-client";
 
-// Mock dependencies
+// Mock kernel-client factory.
 vi.mock("@/lib/zerodev/kernel-client", () => ({
   createDeserializedKernelClient: vi.fn(),
-  createSessionKernelClient: vi.fn(),
+}));
+
+// Mock paymaster client + fee parse (allowance pre-read comes from baseClient).
+const { mockReadContract } = vi.hoisted(() => ({ mockReadContract: vi.fn() }));
+
+vi.mock("@/lib/shared/rpc-client", () => ({
+  baseClient: { readContract: mockReadContract },
+}));
+
+vi.mock("@/lib/zerodev/paymaster-client", () => ({
+  createUsdcPaymaster: vi.fn(async () => ({
+    getPaymasterData: vi.fn(),
+    getPaymasterStubData: vi.fn(),
+  })),
+  getPaymasterTreasury: vi.fn(async () => "0x0000000000000000000000000000000000001234"),
+  parsePaymasterFeeFromReceipt: vi.fn(() => 0n),
 }));
 
 vi.mock("viem", async (importOriginal) => {
@@ -32,13 +48,15 @@ describe("Transfer Executor", () => {
   const mockKernelClient = {
     sendUserOperation: vi.fn().mockResolvedValue("0xuserOpHash"),
     waitForUserOperationReceipt: vi.fn().mockResolvedValue({
-      receipt: { transactionHash: "0xtxHash" },
+      receipt: { transactionHash: "0xtxHash", logs: [] },
     }),
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.AGENT_SIMULATION_MODE = "false";
+    // Default: allowance sufficient → no approve call; kernel client is returned.
+    mockReadContract.mockResolvedValue(0n);
   });
 
   describe("validateTransferParams", () => {
@@ -93,11 +111,11 @@ describe("Transfer Executor", () => {
     });
   });
 
-  describe("executeGaslessTransfer", () => {
+  describe("executeUserPaidTransfer", () => {
     it("should use simulation mode when enabled", async () => {
       process.env.AGENT_SIMULATION_MODE = "true";
 
-      const result = await executeGaslessTransfer(mockParams);
+      const result = await executeUserPaidTransfer(mockParams);
 
       expect(result.success).toBe(true);
       expect(result.hash).toBeDefined();
@@ -105,53 +123,60 @@ describe("Transfer Executor", () => {
       expect(createDeserializedKernelClient).not.toHaveBeenCalled();
     });
 
-    it("should execute transfer using deserialized client", async () => {
+    it("should execute transfer with paymaster when allowance sufficient", async () => {
+      // Pretend paymaster already has infinite allowance → only one call (transfer).
+      mockReadContract.mockResolvedValue(BigInt("99999999999999"));
       (createDeserializedKernelClient as any).mockResolvedValue(mockKernelClient);
 
-      const result = await executeGaslessTransfer(mockParams);
+      const result = await executeUserPaidTransfer(mockParams);
 
-      expect(createDeserializedKernelClient).toHaveBeenCalledWith("mockSerialized");
-      expect(mockKernelClient.sendUserOperation).toHaveBeenCalled();
+      expect(createDeserializedKernelClient).toHaveBeenCalledWith(
+        "mockSerialized",
+        expect.objectContaining({ paymaster: expect.anything() })
+      );
+      expect(mockKernelClient.sendUserOperation).toHaveBeenCalledTimes(1);
+      const calls = mockKernelClient.sendUserOperation.mock.calls[0][0].calls;
+      expect(calls.length).toBe(1); // transfer only, approve skipped
       expect(result.success).toBe(true);
       expect(result.hash).toBe("0xtxHash");
     });
 
-    it("should execute transfer using legacy session key", async () => {
-      (createSessionKernelClient as any).mockResolvedValue(mockKernelClient);
+    it("should batch approve+transfer when allowance is below feeCap", async () => {
+      mockReadContract.mockResolvedValue(0n); // no allowance → approve required
+      (createDeserializedKernelClient as any).mockResolvedValue(mockKernelClient);
 
-      const legacyParams = {
-        ...mockParams,
-        serializedAccount: undefined,
-        sessionPrivateKey: "0xpriv" as `0x${string}`,
-      };
+      await executeUserPaidTransfer(mockParams);
 
-      const result = await executeGaslessTransfer(legacyParams);
-
-      expect(createSessionKernelClient).toHaveBeenCalled();
-      expect(result.success).toBe(true);
+      const calls = mockKernelClient.sendUserOperation.mock.calls[0][0].calls;
+      expect(calls.length).toBe(2); // [approve, transfer]
     });
 
-    it("should fail if no authorization provided", async () => {
-      const invalidParams = {
-        ...mockParams,
-        serializedAccount: undefined,
-        sessionPrivateKey: undefined,
-      };
+    it("should return SESSION_UPGRADE_REQUIRED if serializedAccount missing", async () => {
+      const invalidParams = { ...mockParams, serializedAccount: undefined as any };
 
-      // The function catches the error and returns success: false
-      const result = await executeGaslessTransfer(invalidParams);
+      const result = await executeUserPaidTransfer(invalidParams);
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain("No serializedAccount or sessionPrivateKey");
+      expect(result.error).toContain("SESSION_UPGRADE_REQUIRED");
     });
 
     it("should return error if execution fails", async () => {
+      mockReadContract.mockResolvedValue(BigInt("99999999999999")); // skip approve
       (createDeserializedKernelClient as any).mockRejectedValue(new Error("Bundler error"));
 
-      const result = await executeGaslessTransfer(mockParams);
+      const result = await executeUserPaidTransfer(mockParams);
 
       expect(result.success).toBe(false);
       expect(result.error).toBe("Bundler error");
+    });
+
+    it("executeGaslessTransfer alias still routes to user-paid path", async () => {
+      mockReadContract.mockResolvedValue(BigInt("99999999999999"));
+      (createDeserializedKernelClient as any).mockResolvedValue(mockKernelClient);
+
+      const result = await executeGaslessTransfer(mockParams);
+
+      expect(result.success).toBe(true);
     });
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,7 @@
   ],
   "git": {
     "deploymentEnabled": {
-      "main": true,
+      "main": false,
       "*": false
     }
   }


### PR DESCRIPTION
## Summary

Unified **customer-paid USDC send** via the ZeroDev ERC-20 paymaster, the full UX polish from review points #2–#8, plus a CI/CD pipeline that ships schema + app code in the right order.

**Feature**
- Replaces the broken sponsored-send path with a unified customer-paid flow: user pays gas in USDC through the ZeroDev ERC-20 paymaster. Works for both EIP-7702 (Privy embedded) and ERC-4337 wallet users with zero native ETH.
- Collapses four wallet methods (`send` / `sendSponsored` / `enableGaslessTransfers` / `revokeGaslessTransfers`) into a single phase-emitting `sendUsdc()`. New `SendPhase` state machine drives the UI. No setup modal — inline first-send handles new users and v1-session upgrades in one continuous flow.
- UX additions from review (points #2–#8; #1 auto-redeem from vaults explicitly deferred): ENS/Basename resolver with race-safe LRU, success card with actual fee + BaseScan link, recent-recipients quick-pick strip, clipboard paste chip, limits helper.
- Fail-closed Redis idempotency, CallPolicy v2 with `approve(paymaster, ≤FEE_CAP)` pinned by spender, additive migrations (0005 backfill `permissionsVersion=1`; 0006 `transfer_history` table).
- Agent rebalance path remains sponsored — paymaster is only wired on `/api/transfer/send`.

**CI/CD automation**
- `ci.yml` runs `pnpm db:migrate` on push to `main` after typecheck + test + security pass. Gated by `github.ref`, safety-railed against meta-only drizzle churn, scoped to a `production` GitHub environment.
- Vercel git auto-deploy is disabled in `vercel.json`. A new `deploy` job calls a Vercel Deploy Hook only after `migrate` succeeds. Strict ordering: schema lands before app code.
- Rollback: flip `ENABLE_USDC_PAYMASTER=false` (server flag) or set `deploymentEnabled.main: true` in `vercel.json` to restore auto-deploy.

## Test Coverage

Full unit suite this run: **513 passed, 1 skipped, 51 files, 46.8s**. TypeScript: clean. No new commits since the prior ship run.

37 new tests across 5 suites:
- `tests/unit/lib/redis/idempotency.test.ts` — Redis wrapper (cache hit, concurrent-lock busy error, per-user key scoping, error path lock release, corrupt-cache recovery).
- `tests/unit/lib/ens/cache.test.ts` + `tests/unit/lib/ens/resolver.test.ts` — LRU semantics + ENS/Basename resolution (0x passthrough, `.eth`, `.base.eth`, RPC failure, race cache).
- `tests/unit/lib/zerodev/paymaster-fee-parse.test.ts` — parses actual USDC fee from the paymaster → treasury Transfer log (multi-log receipt, case-insensitive address match, empty logs).
- `tests/unit/lib/zerodev/transfer-executor.test.ts` — allowance pre-read short-circuit, batched `[approve, transfer]` when allowance below cap, SESSION_UPGRADE_REQUIRED when `serializedAccount` missing, bundler-error propagation.
- `tests/unit/hooks/useWallet.test.ts` — `sendUsdc` phase emission: submitting → confirming → success for v2, inline `signing_session → registering` for new users and v1-session upgrades, missing `permissionsVersion` treated as v1, Idempotency-Key header plumbing, `SendError` code propagation, `SESSION_SETUP_FAILED` when registration POST fails, `label` passthrough to the send body.
- `tests/unit/lib/zerodev/session.test.ts` — CT-2 regression guard: `permissionsVersion: 2` stamped on session, exactly two permissions (transfer + approve), approve spender **pinned** via `ParamCondition.EQUAL` to the paymaster address (this is THE security invariant — a leaked session key must not be able to approve arbitrary contracts).

Tests: 476 → 513 (+37 new) in this PR.

## Pre-Landing Review

SPARC spec / pseudocode / architecture authored in `tasks/` during planning. Key architecture invariants, each backed by a test:

- Paymaster threaded through the `duplicate permissionHash` retry in `lib/zerodev/kernel-client.ts` so retried UserOps don't silently drop sponsorship.
- `USDC.approve` spender pinned via `ParamCondition.EQUAL` in `lib/zerodev/transfer-session.ts` — test asserts drift to `LESS_THAN_OR_EQUAL` or null would break.
- Agent rebalance path (`/api/optimize` → Sentinel) still calls `createDeserializedKernelClient` without a paymaster (CT-3 regression guard).
- CI migrate job is scoped to `production` GitHub environment; `PRODUCTION_DATABASE_URL` secret never leaks into PR workflows.
- Deploy hook replaces git auto-deploy; rollback path documented in commit message.

## Env vars required

Add to Vercel **Production** (and **Preview** for smoke):

```
NEXT_PUBLIC_ENABLE_USDC_PAYMASTER=true
ENABLE_USDC_PAYMASTER=false              # flip to true after smoke
NEXT_PUBLIC_ERPC_URL=<existing eRPC base URL>    # /main/evm/1 auto-appended for ENS
```

Existing `PAYMASTER_URL` / `ZERODEV_PROJECT_ID` / `REDIS_URL` reused.

Add to GitHub **Environments → production**:

```
PRODUCTION_DATABASE_URL=<production Postgres connection string>
VERCEL_DEPLOY_HOOK_URL=<from Vercel → Settings → Git → Deploy Hooks>
```

## Plan Completion

Scope agreed during planning: Option 2 (no `/estimate` endpoint, static `FEE_CAP_USDC=0.20`) + UX points #2–#8. #1 (auto-redeem from vaults) explicitly deferred to v1.1. All 13 planned tasks completed plus three CI automation follow-ups (migrate job, deploy hook, regression-guard tests).

## TODOS

No TODOS.md in repo — nothing to mark.

## Test plan

- [ ] Create GitHub environment `production`, add `PRODUCTION_DATABASE_URL` + `VERCEL_DEPLOY_HOOK_URL` secrets.
- [ ] Create Vercel Deploy Hook (Settings → Git → Deploy Hooks, branch `main`), copy URL into `VERCEL_DEPLOY_HOOK_URL`.
- [ ] Ship with `ENABLE_USDC_PAYMASTER=false`; first push to main runs migrate + deploy hook.
- [ ] Verify schema applied (`psql`, check `transfer_history` table + `__drizzle_migrations` row).
- [ ] Verify Vercel deployed once migrate was green.
- [ ] Flip `ENABLE_USDC_PAYMASTER=true` on Vercel (no redeploy needed).
- [ ] Staff smoke in production: first-send inline flow, ENS/Basename resolution, receipt fee accuracy, recent-recipients strip, clipboard paste chip, rate-limit helper copy.
- [ ] Regression: agent rebalance (`/api/optimize` / Sentinel cron) still submits UserOps **without** paymaster.

**Rollback:** flip `ENABLE_USDC_PAYMASTER=false` for instant feature kill. For CI-level rollback, set `deploymentEnabled.main: true` in `vercel.json` to restore git auto-deploy; migrations are additive so no data risk.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)